### PR TITLE
fix: correctly handle parenthesised FunctionExpressions

### DIFF
--- a/.changeset/fresh-dolphins-grow.md
+++ b/.changeset/fresh-dolphins-grow.md
@@ -1,0 +1,5 @@
+---
+'esrap': patch
+---
+
+fix: correctly handle parenthesised FunctionExpressions

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -1054,7 +1054,8 @@ const handlers = {
 		if (
 			node.expression.type === 'ObjectExpression' ||
 			(node.expression.type === 'AssignmentExpression' &&
-				node.expression.left.type === 'ObjectPattern')
+				node.expression.left.type === 'ObjectPattern') ||
+			node.expression.type === 'FunctionExpression'
 		) {
 			// is an AssignmentExpression to an ObjectPattern
 			state.commands.push('(');

--- a/test/samples/function-expression/expected.js
+++ b/test/samples/function-expression/expected.js
@@ -1,0 +1,3 @@
+(function () {});
+
+let object = { foo() {} };

--- a/test/samples/function-expression/expected.js.map
+++ b/test/samples/function-expression/expected.js.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": [
+    "input.js"
+  ],
+  "sourcesContent": [
+    "(function(){\n\n})\nlet object = {\n    foo() {\n        \n    }\n}"
+  ],
+  "mappings": "aAAW,CAAC,AAEZ,CAAC;;IACG,MAAM,KACN,GAAG,GAAG,CAAC,AAEP,CAAC"
+}

--- a/test/samples/function-expression/input.js
+++ b/test/samples/function-expression/input.js
@@ -1,0 +1,8 @@
+(function(){
+
+})
+let object = {
+    foo() {
+        
+    }
+}


### PR DESCRIPTION
This should fix https://github.com/sveltejs/svelte/issues/14595, if you see any issues, feel free to tweak it. 