### PR TITLE
fix: correctly print double escaped backslashes with no raw value

### DIFF
--- a/.changeset/clever-socks-boil.md
+++ b/.changeset/clever-socks-boil.md
@@ -1,0 +1,5 @@
+---
+'esrap': patch
+---
+
+fix: correctly print double escaped backslashes with no raw value

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -119,12 +119,12 @@ function quote(string, char) {
 	let escaped = false;
 
 	for (const c of string) {
-		if (escaped) {
+		if (escaped && c !== '\\') {
 			out += c;
 			escaped = false;
 		} else if (c === '\\') {
 			out += '\\\\';
-			escaped = true;
+			escaped = !escaped;
 		} else if (c === char) {
 			out += '\\' + c;
 		} else if (c === '\n') {

--- a/test/quotes.test.js
+++ b/test/quotes.test.js
@@ -86,8 +86,8 @@ test('does not escape already-escaped single quotes', () => {
 	expect(code).toMatchInlineSnapshot(`"const str = 'a\\'b';"`);
 });
 
-test('correctly handle double escaped backslashes when theres no raw', () => {
-	// doing this since if there's a raw value it will prefer that
+test.only('correctly handle double escaped backslashes when theres no raw', () => {
+	// not using load because for some reason acorn parses the value of the literal as `\\` instead of `\\\\`
 	const ast = {
 		type: 'VariableDeclaration',
 		kind: 'var',

--- a/test/quotes.test.js
+++ b/test/quotes.test.js
@@ -86,6 +86,42 @@ test('does not escape already-escaped single quotes', () => {
 	expect(code).toMatchInlineSnapshot(`"const str = 'a\\'b';"`);
 });
 
+test('correctly handle double escaped backslashes when theres no raw', () => {
+	// doing this since if there's a raw value it will prefer that
+	const ast = {
+		type: 'VariableDeclaration',
+		kind: 'var',
+		declarations: [
+			{
+				type: 'VariableDeclarator',
+				id: {
+					type: 'Identifier',
+					name: 'text'
+				},
+				init: {
+					type: 'CallExpression',
+					callee: {
+						type: 'Identifier',
+						name: '$.text'
+					},
+					arguments: [
+						{
+							type: 'Literal',
+							value: '\\\\'
+						}
+					],
+					optional: false
+				}
+			}
+		]
+	};
+
+	clean(ast);
+	const code = print(ast).code;
+
+	expect(code).toMatchInlineSnapshot(`"var text = $.text('\\\\\\\\');"`);
+});
+
 test('does not escape already-escaped double quotes', () => {
 	const ast = load('const str = "a\\"b"');
 	clean(ast);

--- a/test/quotes.test.js
+++ b/test/quotes.test.js
@@ -86,7 +86,7 @@ test('does not escape already-escaped single quotes', () => {
 	expect(code).toMatchInlineSnapshot(`"const str = 'a\\'b';"`);
 });
 
-test.only('correctly handle double escaped backslashes when theres no raw', () => {
+test('correctly handle double escaped backslashes when theres no raw', () => {
 	// not using load because for some reason acorn parses the value of the literal as `\\` instead of `\\\\`
 	const ast = {
 		type: 'VariableDeclaration',


### PR DESCRIPTION
Closes https://github.com/sveltejs/svelte/issues/15476

A bit of an edge case but a valid usecase nontheless.