### PR TITLE
fix: consistently escape escape characters

### DIFF
--- a/.changeset/gold-toys-study.md
+++ b/.changeset/gold-toys-study.md
@@ -1,0 +1,5 @@
+---
+'esrap': patch
+---
+
+fix: consistently escape escape characters

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -116,15 +116,10 @@ function prepend_comments(comments, state, newlines) {
  */
 function quote(string, char) {
 	let out = char;
-	let escaped = false;
 
 	for (const c of string) {
-		if (escaped) {
-			out += c;
-			escaped = false;
-		} else if (c === '\\') {
+		if (c === '\\') {
 			out += '\\\\';
-			escaped = true;
 		} else if (c === char) {
 			out += '\\' + c;
 		} else if (c === '\n') {

--- a/test/quotes.test.js
+++ b/test/quotes.test.js
@@ -82,6 +82,22 @@ test('escapes escape characters', () => {
 	expect(code).toMatchInlineSnapshot(`"const str = 'a\\\\nb';"`);
 });
 
+test('escapes escape characters#2', () => {
+	const ast = load('const str = "a\\\\\\nb"');
+	clean(ast);
+	const code = print(ast).code;
+
+	expect(code).toMatchInlineSnapshot(`"const str = 'a\\\\\\nb';"`);
+});
+
+test('escapes double escaped backslashes', () => {
+	const ast = load("var text = $.text('\\\\\\\\');");
+	clean(ast);
+	const code = print(ast).code;
+
+	expect(code).toMatchInlineSnapshot(`"var text = $.text('\\\\\\\\');"`);
+});
+
 test('does not escape already-escaped single quotes', () => {
 	const ast = load(`const str = 'a\\'b'`);
 	clean(ast);


### PR DESCRIPTION
Remove the "already escaped" logic as it was buggy, we should just always escape escape characters

closes #56
fixes https://github.com/sveltejs/svelte/issues/15476
fixes #57