### PR TITLE
fix: support `implements`

### DIFF
--- a/.changeset/selfish-crews-complain.md
+++ b/.changeset/selfish-crews-complain.md
@@ -1,0 +1,5 @@
+---
+'esrap': patch
+---
+
+fix: support `implements` with an empty array and with more than 1

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -516,9 +516,9 @@ export default (options = {}) => {
 				context.write(' ');
 			}
 
-			if (node.implements) {
-				context.write('implements ');
-				sequence(context, node.implements, node.body.loc?.start ?? null, false);
+			if (node.implements && node.implements.length > 0) {
+				context.write('implements');
+				sequence(context, node.implements, node.body.loc?.start ?? null, true);
 			}
 
 			context.visit(node.body);

--- a/test/samples/ts-implements/expected.ts
+++ b/test/samples/ts-implements/expected.ts
@@ -1,0 +1,6 @@
+interface SelectableControl { select(): void }
+interface Scrollable { scroll(): void }
+
+class Button implements SelectableControl, Scrollable {
+	select() {}
+}

--- a/test/samples/ts-implements/expected.ts.map
+++ b/test/samples/ts-implements/expected.ts.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": [
+    "input.js"
+  ],
+  "sourcesContent": [
+    "interface SelectableControl {\n\tselect(): void;\n}\n\ninterface Scrollable {\n\tscroll(): void;\n}\n\nclass Button implements SelectableControl, Scrollable {\n\tselect() {}\n}\n"
+  ],
+  "mappings": "UAAU,iBAAiB,GAC1B,MAAM,IAAI,IAAI;UAGL,UAAU,GACnB,MAAM,IAAI,IAAI;;MAGT,MAAM,YAAY,iBAAiB,EAAE,UAAU,CAAC,CAAC;CACtD,MAAM,GAAG,CAAC,AAAA,CAAC;AACZ,CAAC"
+}

--- a/test/samples/ts-implements/input.ts
+++ b/test/samples/ts-implements/input.ts
@@ -1,0 +1,11 @@
+interface SelectableControl {
+	select(): void;
+}
+
+interface Scrollable {
+	scroll(): void;
+}
+
+class Button implements SelectableControl, Scrollable {
+	select() {}
+}

--- a/test/samples/ts-interfaces/expected.ts
+++ b/test/samples/ts-interfaces/expected.ts
@@ -13,7 +13,7 @@ class Control {
 
 interface SelectableControl extends Control { select(): void }
 
-class Button extends Control implements SelectableControl{
+class Button extends Control implements SelectableControl {
 	select() {}
 }
 

--- a/test/samples/ts-interfaces/expected.ts.map
+++ b/test/samples/ts-interfaces/expected.ts.map
@@ -7,5 +7,5 @@
   "sourcesContent": [
     "interface Test {\n\tfunc: (a: string) => Promise<void>;\n\tfunc2: () => Promise<void>;\n\ta: number;\n\tb: boolean;\n}\n\ninterface IndexSignature {\n\t[key: string]: string;\n}\n\nclass Control {\n\tprivate state: any;\n}\n\ninterface SelectableControl extends Control {\n\tselect(): void;\n}\n\nclass Button extends Control implements SelectableControl {\n\tselect() {}\n}\n\nclass TextBox extends Control {\n\tselect() {}\n}\n"
   ],
-  "mappings": "UAAU,IAAI;CACb,IAAI,GAAG,CAAS,EAAN,MAAM,KAAK,OAAO,CAAC,IAAI;CACjC,KAAK,QAAQ,OAAO,CAAC,IAAI;CACzB,CAAC,EAAE,MAAM;CACT,CAAC,EAAE,OAAO;;;UAGD,cAAc,IACtB,GAAW,EAAN,MAAM,GAAG,MAAM;;MAGhB,OAAO,CAAC,CAAC;SACN,KAAK,EAAE,GAAG;AACnB,CAAC;;UAES,iBAAiB,SAAS,OAAO,GAC1C,MAAM,IAAI,IAAI;;MAGT,MAAM,SAAS,OAAO,YAAY,iBAAiB,AAAC,CAAC;CAC1D,MAAM,GAAG,CAAC,AAAA,CAAC;AACZ,CAAC;;MAEK,OAAO,SAAS,OAAO,CAAC,CAAC;CAC9B,MAAM,GAAG,CAAC,AAAA,CAAC;AACZ,CAAC"
+  "mappings": "UAAU,IAAI;CACb,IAAI,GAAG,CAAS,EAAN,MAAM,KAAK,OAAO,CAAC,IAAI;CACjC,KAAK,QAAQ,OAAO,CAAC,IAAI;CACzB,CAAC,EAAE,MAAM;CACT,CAAC,EAAE,OAAO;;;UAGD,cAAc,IACtB,GAAW,EAAN,MAAM,GAAG,MAAM;;MAGhB,OAAO,CAAC,CAAC;SACN,KAAK,EAAE,GAAG;AACnB,CAAC;;UAES,iBAAiB,SAAS,OAAO,GAC1C,MAAM,IAAI,IAAI;;MAGT,MAAM,SAAS,OAAO,YAAY,iBAAiB,CAAC,CAAC;CAC1D,MAAM,GAAG,CAAC,AAAA,CAAC;AACZ,CAAC;;MAEK,OAAO,SAAS,OAAO,CAAC,CAAC;CAC9B,MAAM,GAAG,CAAC,AAAA,CAAC;AACZ,CAAC"
 }


### PR DESCRIPTION
- [x] with `oxc` parser, we get `implements: []` and that was producing `class Empty implements {}`. Now checking the length as well.
- [x] added a test case with multiple `implements`
- [x] tweaked the end space.