### PR TITLE
better comment placement

### DIFF
--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -290,7 +290,8 @@ export default (options = {}) => {
 		let prev_type = null;
 		let prev_multiline = false;
 
-		for (const child of node.body) {
+		for (let i = 0; i < node.body.length; i += 1) {
+			const child = node.body[i];
 			if (child.type === 'EmptyStatement') continue;
 
 			const child_context = context.new();
@@ -305,6 +306,12 @@ export default (options = {}) => {
 			}
 
 			context.append(child_context);
+
+			flush_trailing_comments(
+				context,
+				child.loc?.end || null,
+				node.body[i + 1]?.loc?.end ?? node.loc?.end ?? null
+			);
 
 			prev_type = child.type;
 			prev_multiline = child_context.multiline;
@@ -579,17 +586,11 @@ export default (options = {}) => {
 
 	return {
 		_(node, context, visit) {
-			const is_statement = /(Statement|Declaration)$/.test(node.type);
-
 			if (node.loc) {
 				flush_comments_until(context, null, node.loc.start, true);
 			}
 
 			visit(node);
-
-			if (is_statement && node.loc) {
-				flush_trailing_comments(context, node.loc.end, null);
-			}
 		},
 
 		ArrayExpression: shared['ArrayExpression|ArrayPattern'],

--- a/test/samples/comment-after-function-argument/expected.js
+++ b/test/samples/comment-after-function-argument/expected.js
@@ -1,0 +1,6 @@
+foo(
+	function bar() {
+		// logic goes here
+	},
+	true
+); // trailing comment

--- a/test/samples/comment-after-function-argument/expected.js.map
+++ b/test/samples/comment-after-function-argument/expected.js.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": [
+    "input.js"
+  ],
+  "sourcesContent": [
+    "foo(function bar() {\n\t// logic goes here\n}, true); // trailing comment\n"
+  ],
+  "mappings": "AAAA,GAAG;UAAU,GAAG,GAAG,CAAC;;CAEpB,CAAC;CAAE,IAAI;"
+}

--- a/test/samples/comment-after-function-argument/input.js
+++ b/test/samples/comment-after-function-argument/input.js
@@ -1,0 +1,3 @@
+foo(function bar() {
+	// logic goes here
+}, true); // trailing comment

--- a/test/samples/comment-between-blocks/expected.js
+++ b/test/samples/comment-between-blocks/expected.js
@@ -1,7 +1,7 @@
 // if true, yep
 if (condition) {
 	console.log('yep');
-} // otherwise nope
-else {
+} else // otherwise nope
+{
 	console.log('nope');
 }

--- a/test/samples/comment-between-blocks/expected.js.map
+++ b/test/samples/comment-between-blocks/expected.js.map
@@ -7,5 +7,5 @@
   "sourcesContent": [
     "// if true, yep\nif (condition) {\n\tconsole.log('yep');\n} // otherwise nope\nelse {\n\tconsole.log('nope');\n}\n"
   ],
-  "mappings": ";IACI,SAAS,EAAE,CAAC;CACf,OAAO,CAAC,GAAG,CAAC,KAAK;AAClB,CAAC;KACI,CAAC;CACL,OAAO,CAAC,GAAG,CAAC,MAAM;AACnB,CAAC"
+  "mappings": ";IACI,SAAS,EAAE,CAAC;CACf,OAAO,CAAC,GAAG,CAAC,KAAK;AAClB,CAAC;AACI,CAAC;CACL,OAAO,CAAC,GAAG,CAAC,MAAM;AACnB,CAAC"
 }


### PR DESCRIPTION
follow-up to #73 — handles trailing comments after statements in `body(...)` rather than as a special case inside the universal visitor, which yields better results in cases like this:

```js
foo(function bar() {
  // logic goes here
}, true); // trailing comment
```

before:

```js
foo(
  function bar() {
    // logic goes here
  } // trailing comment
  ,
  true
);
```

after:

```js
foo(
  function bar() {
    // logic goes here
  },
  true
); // trailing comment
```