### PR TITLE
Improve OXC Support

### DIFF
--- a/.changeset/fifty-dolls-divide.md
+++ b/.changeset/fifty-dolls-divide.md
@@ -1,0 +1,5 @@
+---
+'esrap': patch
+---
+
+Properly print `ParenthesizedExpression`s

--- a/.changeset/twelve-parents-battle.md
+++ b/.changeset/twelve-parents-battle.md
@@ -1,0 +1,5 @@
+---
+'esrap': minor
+---
+
+Introduce `resolveIndexedLocations` helper

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -337,7 +337,7 @@ export default (options = {}) => {
 			context.write('[');
 			sequence(
 				context,
-				/** @type {TSESTree.Node[]} */ (node.elements),
+				/** @type {TSESTree.Node[]} */(node.elements),
 				node.loc?.end ?? null,
 				false
 			);
@@ -1067,7 +1067,9 @@ export default (options = {}) => {
 
 		// @ts-expect-error this isn't a real node type, but Acorn produces it
 		ParenthesizedExpression(node, context) {
-			return context.visit(node.expression);
+			context.write('(');
+			context.visit(node.expression);
+			context.write(')');
 		},
 
 		PrivateIdentifier(node, context) {


### PR DESCRIPTION
This pull request makes the following improvements:

1. Previously, when we were printing `ParenthesizedExpression`s, we would just naively print the node inside of it, instead of parenthesizing it. I am not quite sure why, but that is now fixed.<sup>[1]</sup>
2. I added a helper called `resolveIndexedLocations`
   <details>
   <summary>
   Why is this needed?
   </summary>
   Sourcemaps don't let you explicitly specify the index of a location, but rather require a row and column number. This would be fine (if not slightly silly), if it weren't for the output of `oxc-parser` containing `start` and `end` fields, which use indicies rather than row and column numbers. Thus, we must have the original source code to turn said indicies into row and column numbers, which is not guranteed with the typical `print` api, so I created a wrapper around normal languages (which requires the source code to create), that adds a catch-all function to support the `oxc` style nodes. If I had more time, I could've made this more concise, sorry.
   </details>

And of course, I added changesets for these as well.

###### <sup>[1]</sup>I didn't just do this because it seemed off, it was actively causing problems because of how `oxc-parser` parses IIFEs