### PR TITLE
feat: add `additionalComments` option for programmatic comment insertion

### DIFF
--- a/.changeset/pretty-spiders-hear.md
+++ b/.changeset/pretty-spiders-hear.md
@@ -1,0 +1,5 @@
+---
+'esrap': minor
+---
+
+feat: add additionalComments option for programmatic comment insertion

--- a/README.md
+++ b/README.md
@@ -55,7 +55,12 @@ const { code, map } = print(
     quotes: 'single',
 
     // an array of `{ type: 'Line' | 'Block', value: string, loc: { start, end } }` objects
-    comments: []
+    comments: [],
+
+    // a WeakMap of AST nodes to additional comments to insert at specific nodes
+    // useful for programmatically adding comments during code transformation,
+    // especially for nodes that were added programmatically
+    additionalComments: new WeakMap()
   })
 );
 ```

--- a/src/languages/types.d.ts
+++ b/src/languages/types.d.ts
@@ -1,6 +1,9 @@
+import { TSESTree } from '@typescript-eslint/types';
+
 export type TSOptions = {
 	quotes?: 'double' | 'single';
 	comments?: Comment[];
+	additionalComments?: WeakMap<TSESTree.Node, AdditionalComment[]>;
 };
 
 interface Position {
@@ -10,13 +13,20 @@ interface Position {
 
 // this exists in TSESTree but because of the inanity around enums
 // it's easier to do this ourselves
-export interface Comment {
+export interface BaseComment {
 	type: 'Line' | 'Block';
 	value: string;
 	start?: number;
 	end?: number;
+}
+
+export interface Comment extends BaseComment {
 	loc: {
 		start: Position;
 		end: Position;
 	};
+}
+
+export interface AdditionalComment extends BaseComment {
+	position: 'leading' | 'trailing';
 }

--- a/test/additional-comments.test.js
+++ b/test/additional-comments.test.js
@@ -1,0 +1,105 @@
+// @ts-check
+/** @import { TSESTree } from '@typescript-eslint/types' */
+/** @import { AdditionalComment } from '../src/languages/types.js' */
+import { expect, test } from 'vitest';
+import { print } from '../src/index.js';
+import { load } from './common.js';
+import ts from '../src/languages/ts/index.js';
+
+/**
+ * Helper to create additional comments and print code
+ * @param {TSESTree.Program} ast - Parsed AST
+ * @param {TSESTree.Node} node - AST node to attach comments to
+ * @param {AdditionalComment[]} comments - Comments to attach
+ * @returns {string} Generated code
+ */
+function printWithComments(ast, node, comments) {
+	const additionalComments = new WeakMap();
+	additionalComments.set(node, comments);
+
+	const output = print(ast, ts({ additionalComments }));
+	return output.code;
+}
+
+/**
+ * Helper to get return statement from a simple function
+ * @param {TSESTree.Program} ast - Parsed AST
+ * @returns {TSESTree.Node} The return statement
+ */
+function getReturnStatement(ast) {
+	const functionDecl = ast.body[0];
+	// @ts-expect-error accessing function body
+	const statements = functionDecl.body.body;
+	// Find the return statement (could be first or second depending on function structure)
+	return statements.find(/** @param {any} stmt */ (stmt) => stmt.type === 'ReturnStatement');
+}
+
+test('additional comments are inserted correctly', () => {
+	const input = `function example() {
+	const x = 1;
+	return x;
+}`;
+
+	const { ast } = load(input);
+	const returnStatement = getReturnStatement(ast);
+	expect(returnStatement.type).toBe('ReturnStatement');
+
+	/** @type {AdditionalComment[]} */
+	const comments = [
+		{
+			type: 'Line',
+			value: ' This is a leading comment',
+			position: 'leading'
+		},
+		{
+			type: 'Block',
+			value: ' This is a trailing comment ',
+			position: 'trailing'
+		}
+	];
+
+	const code = printWithComments(ast, returnStatement, comments);
+
+	expect(code).toContain('// This is a leading comment');
+	expect(code).toContain('/* This is a trailing comment */');
+});
+
+test('only leading comments are inserted when specified', () => {
+	const input = `function test() { return 42; }`;
+	const { ast } = load(input);
+	const returnStatement = getReturnStatement(ast);
+
+	/** @type {AdditionalComment[]} */
+	const comments = [
+		{
+			type: 'Line',
+			value: ' Leading only',
+			position: 'leading'
+		}
+	];
+
+	const code = printWithComments(ast, returnStatement, comments);
+
+	expect(code).toContain('// Leading only');
+	expect(code).not.toContain('trailing');
+});
+
+test('only trailing comments are inserted when specified', () => {
+	const input = `function test() { return 42; }`;
+	const { ast } = load(input);
+	const returnStatement = getReturnStatement(ast);
+
+	/** @type {AdditionalComment[]} */
+	const comments = [
+		{
+			type: 'Block',
+			value: ' Trailing only ',
+			position: 'trailing'
+		}
+	];
+
+	const code = printWithComments(ast, returnStatement, comments);
+
+	expect(code).toContain('/* Trailing only */');
+	expect(code).not.toContain('//');
+});

--- a/test/additional-comments.test.js
+++ b/test/additional-comments.test.js
@@ -13,7 +13,7 @@ import ts from '../src/languages/ts/index.js';
  * @param {AdditionalComment[]} comments - Comments to attach
  * @returns {string} Generated code
  */
-function printWithComments(ast, node, comments) {
+function print_with_comments(ast, node, comments) {
 	const additionalComments = new WeakMap();
 	additionalComments.set(node, comments);
 
@@ -26,7 +26,7 @@ function printWithComments(ast, node, comments) {
  * @param {TSESTree.Program} ast - Parsed AST
  * @returns {TSESTree.Node} The return statement
  */
-function getReturnStatement(ast) {
+function get_return_statement(ast) {
 	const functionDecl = ast.body[0];
 	// @ts-expect-error accessing function body
 	const statements = functionDecl.body.body;
@@ -41,7 +41,7 @@ test('additional comments are inserted correctly', () => {
 }`;
 
 	const { ast } = load(input);
-	const returnStatement = getReturnStatement(ast);
+	const returnStatement = get_return_statement(ast);
 	expect(returnStatement.type).toBe('ReturnStatement');
 
 	/** @type {AdditionalComment[]} */
@@ -58,7 +58,7 @@ test('additional comments are inserted correctly', () => {
 		}
 	];
 
-	const code = printWithComments(ast, returnStatement, comments);
+	const code = print_with_comments(ast, returnStatement, comments);
 
 	expect(code).toContain('// This is a leading comment');
 	expect(code).toContain('/* This is a trailing comment */');
@@ -67,7 +67,7 @@ test('additional comments are inserted correctly', () => {
 test('only leading comments are inserted when specified', () => {
 	const input = `function test() { return 42; }`;
 	const { ast } = load(input);
-	const returnStatement = getReturnStatement(ast);
+	const returnStatement = get_return_statement(ast);
 
 	/** @type {AdditionalComment[]} */
 	const comments = [
@@ -78,7 +78,7 @@ test('only leading comments are inserted when specified', () => {
 		}
 	];
 
-	const code = printWithComments(ast, returnStatement, comments);
+	const code = print_with_comments(ast, returnStatement, comments);
 
 	expect(code).toContain('// Leading only');
 	expect(code).not.toContain('trailing');
@@ -87,7 +87,7 @@ test('only leading comments are inserted when specified', () => {
 test('only trailing comments are inserted when specified', () => {
 	const input = `function test() { return 42; }`;
 	const { ast } = load(input);
-	const returnStatement = getReturnStatement(ast);
+	const returnStatement = get_return_statement(ast);
 
 	/** @type {AdditionalComment[]} */
 	const comments = [
@@ -98,7 +98,7 @@ test('only trailing comments are inserted when specified', () => {
 		}
 	];
 
-	const code = printWithComments(ast, returnStatement, comments);
+	const code = print_with_comments(ast, returnStatement, comments);
 
 	expect(code).toContain('/* Trailing only */');
 	expect(code).not.toContain('//');


### PR DESCRIPTION
Imagine parsing an AST, making a few codemods and printing the AST again. All comment handling up until now is based on knowing where exactly the node is located (based on its `loc` property). While doing codemods you might add new nodes programmatically that therefore do not have any `loc` property. Thus, `esrap` understandably fails to print comments for them.

We don't want to move away from handling most comments via `loc`, as this is by far the most reliable way.

To support the codemod use case, I created a new option `additionalComments`. These comments use the leading/trailing pattern and are therefore not as accurate as the `loc` ones, but it's easily possible to add them to the printed code.

```js
const additionalComments = new WeakMap();
additionalComments.set(syntheticNode, [
  { type: 'Line', value: ' Generated during codemod', position: 'leading' }
]);
print(ast, ts({ additionalComments }));
```

I also considered calling these comments syntheticComments instead of additional, but for me, it didn't feel right. Happy for better suggestions.