### PR TITLE
fix: make @typescript-eslint/types an optional peer dependency

### DIFF
--- a/.changeset/fix-type-compat.md
+++ b/.changeset/fix-type-compat.md
@@ -1,0 +1,7 @@
+---
+'esrap': patch
+---
+
+fix: make `@typescript-eslint/types` an optional peer dependency
+
+`print()` is also used in non-TypeScript contexts (e.g. with `@types/estree` nodes), where `@typescript-eslint/types` as a regular dependency can cause type conflicts. Now optional, so `ts()`/`tsx()` visitors work with any node type.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 	"scripts": {
 		"changeset:version": "changeset version",
 		"changeset:publish": "changeset publish",
-		"check": "tsc",
+		"check": "dts-buddy -m esrap:./src/public.d.ts -m esrap/languages/ts:./src/languages/ts/public.d.ts -m esrap/languages/tsx:./src/languages/tsx/public.d.ts && tsc",
 		"prepublishOnly": "pnpm test && dts-buddy -m esrap:./src/public.d.ts -m esrap/languages/ts:./src/languages/ts/public.d.ts -m esrap/languages/tsx:./src/languages/tsx/public.d.ts",
 		"sandbox": "node test/sandbox/index.js",
 		"test": "vitest --run",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
 	"devDependencies": {
 		"@changesets/cli": "^2.27.11",
 		"@sveltejs/acorn-typescript": "^1.0.5",
+		"@types/estree": "^1.0.8",
+		"@typescript-eslint/types": "^8.2.0",
 		"@vitest/ui": "^2.1.1",
 		"acorn": "^8.15.0",
 		"dts-buddy": "^0.6.2",
@@ -51,8 +53,15 @@
 	},
 	"license": "MIT",
 	"dependencies": {
-		"@jridgewell/sourcemap-codec": "^1.4.15",
+		"@jridgewell/sourcemap-codec": "^1.4.15"
+	},
+	"peerDependencies": {
 		"@typescript-eslint/types": "^8.2.0"
+	},
+	"peerDependenciesMeta": {
+		"@typescript-eslint/types": {
+			"optional": true
+		}
 	},
 	"packageManager": "pnpm@9.8.0",
 	"publishConfig": {

--- a/package.json
+++ b/package.json
@@ -43,8 +43,9 @@
 	"scripts": {
 		"changeset:version": "changeset version",
 		"changeset:publish": "changeset publish",
-		"check": "dts-buddy -m esrap:./src/public.d.ts -m esrap/languages/ts:./src/languages/ts/public.d.ts -m esrap/languages/tsx:./src/languages/tsx/public.d.ts && tsc",
-		"prepublishOnly": "pnpm test && dts-buddy -m esrap:./src/public.d.ts -m esrap/languages/ts:./src/languages/ts/public.d.ts -m esrap/languages/tsx:./src/languages/tsx/public.d.ts",
+		"gen": "dts-buddy -m esrap:./src/public.d.ts -m esrap/languages/ts:./src/languages/ts/public.d.ts -m esrap/languages/tsx:./src/languages/tsx/public.d.ts",
+		"check": "pnpm gen && tsc",
+		"prepublishOnly": "pnpm test && pnpm gen",
 		"sandbox": "node test/sandbox/index.js",
 		"test": "vitest --run",
 		"test:ui": "vitest --ui",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@jridgewell/sourcemap-codec':
         specifier: ^1.4.15
         version: 1.5.0
-      '@typescript-eslint/types':
-        specifier: ^8.2.0
-        version: 8.46.1
     devDependencies:
       '@changesets/cli':
         specifier: ^2.27.11
@@ -21,6 +18,12 @@ importers:
       '@sveltejs/acorn-typescript':
         specifier: ^1.0.5
         version: 1.0.5(acorn@8.15.0)
+      '@types/estree':
+        specifier: ^1.0.8
+        version: 1.0.8
+      '@typescript-eslint/types':
+        specifier: ^8.2.0
+        version: 8.46.1
       '@vitest/ui':
         specifier: ^2.1.1
         version: 2.1.1(vitest@2.1.1)
@@ -481,6 +484,9 @@ packages:
 
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -1492,6 +1498,8 @@ snapshots:
 
   '@types/estree@1.0.5': {}
 
+  '@types/estree@1.0.8': {}
+
   '@types/node@12.20.55': {}
 
   '@types/node@20.12.14':
@@ -1655,7 +1663,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.8
 
   extendable-error@0.1.7: {}
 

--- a/src/languages/ts/public.d.ts
+++ b/src/languages/ts/public.d.ts
@@ -1,2 +1,6 @@
-export * from './index';
-export type { BaseComment, Comment } from '../types';
+import type { Visitors, BaseNode } from '../../types';
+import type { TSOptions, BaseComment, Comment } from '../types';
+export type { BaseComment, Comment };
+export type { TSOptions };
+export default function ts(options?: TSOptions): Visitors<BaseNode>;
+export declare const EXPRESSIONS_PRECEDENCE: Record<string, number>;

--- a/src/languages/ts/public.d.ts
+++ b/src/languages/ts/public.d.ts
@@ -1,7 +1,6 @@
 import type { Visitors, BaseNode } from '../../types';
 import type { TSOptions, BaseComment, Comment } from '../types';
 export type { BaseComment, Comment };
-export type { TSOptions };
 export type Node = BaseNode;
 export default function ts(options?: TSOptions): Visitors<BaseNode>;
 // was Record<TSESTree.Expression['type'] | 'Super' | 'RestElement', number>

--- a/src/languages/ts/public.d.ts
+++ b/src/languages/ts/public.d.ts
@@ -2,5 +2,6 @@ import type { Visitors, BaseNode } from '../../types';
 import type { TSOptions, BaseComment, Comment } from '../types';
 export type { BaseComment, Comment };
 export type { TSOptions };
+export type Node = BaseNode;
 export default function ts(options?: TSOptions): Visitors<BaseNode>;
 export declare const EXPRESSIONS_PRECEDENCE: Record<string, number>;

--- a/src/languages/ts/public.d.ts
+++ b/src/languages/ts/public.d.ts
@@ -4,4 +4,5 @@ export type { BaseComment, Comment };
 export type { TSOptions };
 export type Node = BaseNode;
 export default function ts(options?: TSOptions): Visitors<BaseNode>;
+// was Record<TSESTree.Expression['type'] | 'Super' | 'RestElement', number>
 export declare const EXPRESSIONS_PRECEDENCE: Record<string, number>;

--- a/src/languages/tsx/public.d.ts
+++ b/src/languages/tsx/public.d.ts
@@ -1,2 +1,5 @@
-export * from './index';
-export type { BaseComment, Comment } from '../types';
+import type { Visitors, BaseNode } from '../../types';
+import type { TSOptions, BaseComment, Comment } from '../types';
+export type { BaseComment, Comment };
+export type { TSOptions };
+export default function tsx(options?: TSOptions): Visitors<BaseNode>;

--- a/src/languages/tsx/public.d.ts
+++ b/src/languages/tsx/public.d.ts
@@ -2,4 +2,5 @@ import type { Visitors, BaseNode } from '../../types';
 import type { TSOptions, BaseComment, Comment } from '../types';
 export type { BaseComment, Comment };
 export type { TSOptions };
+export type Node = BaseNode;
 export default function tsx(options?: TSOptions): Visitors<BaseNode>;

--- a/src/languages/tsx/public.d.ts
+++ b/src/languages/tsx/public.d.ts
@@ -1,6 +1,5 @@
 import type { Visitors, BaseNode } from '../../types';
 import type { TSOptions, BaseComment, Comment } from '../types';
 export type { BaseComment, Comment };
-export type { TSOptions };
 export type Node = BaseNode;
 export default function tsx(options?: TSOptions): Visitors<BaseNode>;

--- a/src/public.d.ts
+++ b/src/public.d.ts
@@ -1,2 +1,21 @@
 export type { PrintOptions, Visitors } from './types';
-export * from './index';
+export { Context } from './index';
+
+import type { BaseNode, PrintOptions, Visitors } from './types';
+
+export function print<T extends BaseNode = BaseNode>(
+	node: T,
+	visitors: Visitors<T>,
+	opts?: PrintOptions
+): {
+	code: string;
+	map: any;
+};
+export function print(
+	node: BaseNode,
+	visitors: Record<string, Function>,
+	opts?: PrintOptions
+): {
+	code: string;
+	map: any;
+};

--- a/src/public.d.ts
+++ b/src/public.d.ts
@@ -1,21 +1,2 @@
 export type { PrintOptions, Visitors } from './types';
-export { Context } from './index';
-
-import type { BaseNode, PrintOptions, Visitors } from './types';
-
-export function print<T extends BaseNode = BaseNode>(
-	node: T,
-	visitors: Visitors<T>,
-	opts?: PrintOptions
-): {
-	code: string;
-	map: any;
-};
-export function print(
-	node: BaseNode,
-	visitors: Record<string, Function>,
-	opts?: PrintOptions
-): {
-	code: string;
-	map: any;
-};
+export * from './index';

--- a/test/compat.test.js
+++ b/test/compat.test.js
@@ -8,6 +8,7 @@
 import { expect, test } from 'vitest';
 import { parse } from 'acorn';
 import { print } from 'esrap';
+// we use ts from esrap/languages/ts instead source in purpose
 import ts from 'esrap/languages/ts';
 import { acornParse } from './common.js';
 

--- a/test/compat.test.js
+++ b/test/compat.test.js
@@ -1,6 +1,9 @@
+// @ts-check
 // Verify that print() accepts nodes from different type systems
-// without type errors (e.g. @types/estree vs @typescript-eslint/types)
-// `pnpm check` should pass
+// without type errors (e.g. @types/estree vs @typescript-eslint/types).
+// The runtime behavior is identical - these tests exist to catch
+// type incompatibilities that would break consumers at `tsc` time.
+// See also: `pnpm check`
 
 import { expect, test } from 'vitest';
 import { parse } from 'acorn';
@@ -9,12 +12,7 @@ import ts from 'esrap/languages/ts';
 import { acornParse } from './common.js';
 
 test('estree nodes with ts() visitors', () => {
-	const ast = /** @type {import('estree').Node} */ (
-		parse('const x = 1;', {
-			ecmaVersion: 'latest',
-			sourceType: 'module'
-		})
-	);
+	const ast = parse('const x = 1;', { ecmaVersion: 'latest', sourceType: 'module' });
 
 	const { code } = print(ast, ts());
 

--- a/test/compat.test.js
+++ b/test/compat.test.js
@@ -1,0 +1,30 @@
+// Verify that print() accepts nodes from different type systems
+// without type errors (e.g. @types/estree vs @typescript-eslint/types)
+// `pnpm check` should pass
+
+import { expect, test } from 'vitest';
+import { parse } from 'acorn';
+import { print } from 'esrap';
+import ts from 'esrap/languages/ts';
+import { acornParse } from './common.js';
+
+test('estree nodes with ts() visitors', () => {
+	const ast = /** @type {import('estree').Node} */ (
+		parse('const x = 1;', {
+			ecmaVersion: 'latest',
+			sourceType: 'module'
+		})
+	);
+
+	const { code } = print(ast, ts());
+
+	expect(code).toBe('const x = 1;');
+});
+
+test('@typescript-eslint/types nodes with ts() visitors', () => {
+	const { ast } = acornParse('const x: number = 1;');
+
+	const { code } = print(ast, ts());
+
+	expect(code).toBe('const x: number = 1;');
+});


### PR DESCRIPTION
## Context

[sveltejs/svelte.dev CI started failing](https://github.com/sveltejs/svelte.dev/actions/runs/24131977859/job/70410572479) after a docs sync bumped `svelte` to 5.55.1, which pulled in `esrap@2.2.4`.

The error:

```
Property 'parent' is missing in type 'MemberExpression' but required in type 'MemberExpressionNonComputedName'
```

## Root cause

In #99, `@typescript-eslint/types` was moved from `devDependencies` to `dependencies`. This was correct per npm conventions (the published types reference it), but it introduced a side effect: `@typescript-eslint/types` ships a [module augmentation](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/types/src/ts-estree.ts) that adds a `parent` property to every AST node. This makes `TSESTree.Node` structurally incompatible with `@types/estree`'s `Node`.

Any consumer that uses `print()` with `@types/estree` nodes (e.g. from `acorn`) and `ts()` visitors hits a type error - which is exactly what svelte.dev's REPL does:

```ts
return print(transformed, ts()); // transformed is estree.Node
```

This augmentation has existed in `@typescript-eslint/types` since at least v8.2.0 - it was just invisible before #99 because the package wasn't installed in consumers.

## Fix

- Move `@typescript-eslint/types` from `dependencies` to an **optional peer dependency**. Not all `esrap` consumers use the TS/TSX language plugins, so a peer dependency avoids forcing this cost on everyone.
- Explicitly declare the public types for `ts()`/`tsx()` to return `Visitors<BaseNode>` instead of `Visitors<TSESTree.Node>`, removing all `@typescript-eslint/types` references from published types
- Add compat tests covering both `@types/estree` and `@typescript-eslint/types` nodes
- Consumers who need `@typescript-eslint/types` (e.g. for TS parsing) can install it themselves. Consumers who don't (e.g. using `acorn`) are no longer affected.