### PR TITLE
fix: print aliased inline type import specifiers as 'type X as Y'

### DIFF
--- a/.changeset/fix-aliased-inline-type-import.md
+++ b/.changeset/fix-aliased-inline-type-import.md
@@ -1,0 +1,10 @@
+---
+'esrap': patch
+---
+
+fix: emit valid TS for aliased inline-type import specifiers
+
+`ImportSpecifier` with both `importKind: 'type'` and an alias (e.g.
+`import { type Foo as Bar } from '...'`) was being printed as
+`Foo as type Bar`, which is not valid TypeScript. The `type` keyword now
+precedes the imported identifier instead of the local.

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -1406,6 +1406,8 @@ export default (options = {}) => {
 		},
 
 		ImportSpecifier(node, context) {
+			if (node.importKind == 'type') context.write('type ');
+
 			if (
 				node.local.type === 'Identifier' &&
 				node.imported.type === 'Identifier' &&
@@ -1415,7 +1417,6 @@ export default (options = {}) => {
 				context.write(' as ');
 			}
 
-			if (node.importKind == 'type') context.write('type ');
 			context.visit(node.local);
 		},
 

--- a/test/samples/ts-typed-imports/expected.ts
+++ b/test/samples/ts-typed-imports/expected.ts
@@ -1,3 +1,3 @@
 import type A from 'foo';
 import type { B } from 'foo';
-import { C, type D } from 'foo';
+import { C, type D, type E as F } from 'foo';

--- a/test/samples/ts-typed-imports/expected.ts.map
+++ b/test/samples/ts-typed-imports/expected.ts.map
@@ -5,7 +5,7 @@
     "input.js"
   ],
   "sourcesContent": [
-    "import type A from 'foo';\nimport type { B } from 'foo';\nimport { C, type D } from 'foo';\n"
+    "import type A from 'foo';\nimport type { B } from 'foo';\nimport { C, type D, type E as F } from 'foo';\n"
   ],
-  "mappings": "AAAA,OAAO,AAAA,KAAK,AAAA,CAAC,MAAM,KAAK;AACxB,OAAO,AAAA,KAAK,EAAE,CAAC,QAAQ,KAAK;AAC5B,OAAO,EAAE,CAAC,OAAO,CAAC,QAAQ,KAAK"
+  "mappings": "AAAA,OAAO,AAAA,KAAK,AAAA,CAAC,MAAM,KAAK;AACxB,OAAO,AAAA,KAAK,EAAE,CAAC,QAAQ,KAAK;AAC5B,OAAO,EAAE,CAAC,OAAO,CAAC,OAAO,CAAC,IAAI,CAAC,QAAQ,KAAK"
 }

--- a/test/samples/ts-typed-imports/input.ts
+++ b/test/samples/ts-typed-imports/input.ts
@@ -1,3 +1,3 @@
 import type A from 'foo';
 import type { B } from 'foo';
-import { C, type D } from 'foo';
+import { C, type D, type E as F } from 'foo';


### PR DESCRIPTION
Fixes printing of TS inline-type import specifiers that also have an alias.

Before:
  AST:    `{ type: 'ImportSpecifier', imported: Foo, local: Bar, importKind: 'type' }`
  Output: `import { Foo as type Bar } from '...'`   // invalid TS

After:
  Output: `import { type Foo as Bar } from '...'`   // valid TS

The `type` keyword now precedes the imported identifier rather than the local.
Non-aliased cases (`import { type Foo }`) are unchanged.

Coverage added to test/samples/ts-typed-imports.
