### PR TITLE
fix: keep braces for concise arrow functions with `as/satifies` type suffix

### DIFF
--- a/.changeset/clever-dryers-hear.md
+++ b/.changeset/clever-dryers-hear.md
@@ -1,0 +1,5 @@
+---
+'esrap': patch
+---
+
+fix: keep braces for concise arrow functions with `as/satifies` type suffix

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -1010,12 +1010,7 @@ export default (options = {}) => {
 
 			context.write(' => ');
 
-			if (
-				node.body.type === 'ObjectExpression' ||
-				(node.body.type === 'AssignmentExpression' && node.body.left.type === 'ObjectPattern') ||
-				(node.body.type === 'LogicalExpression' && node.body.left.type === 'ObjectExpression') ||
-				(node.body.type === 'ConditionalExpression' && node.body.test.type === 'ObjectExpression')
-			) {
+			if (arrow_concise_body_needs_wrap(node.body)) {
 				context.write('(');
 				context.visit(node.body);
 				context.write(')');
@@ -2321,6 +2316,34 @@ export default (options = {}) => {
 };
 
 /** @satisfies {Visitors} */
+
+/**
+ * Arrow functions with a concise body must wrap certain expressions in parentheses,
+ * otherwise `{` can start a block statement instead of an object literal (`as` /
+ * `satisfies` / `!` do not change that (e.g. `() => { x } as const`).
+ * @param {TSESTree.BlockStatement | TSESTree.Expression} body
+ * @returns {boolean}
+ */
+function arrow_concise_body_needs_wrap(body) {
+	if (body.type === 'BlockStatement') return false;
+
+	switch (body.type) {
+		case 'ObjectExpression':
+			return true;
+		case 'AssignmentExpression':
+			return body.left.type === 'ObjectPattern';
+		case 'LogicalExpression':
+			return body.left.type === 'ObjectExpression';
+		case 'ConditionalExpression':
+			return body.test.type === 'ObjectExpression';
+		case 'TSAsExpression':
+		case 'TSSatisfiesExpression':
+		case 'TSNonNullExpression':
+			return body.expression ? arrow_concise_body_needs_wrap(body.expression) : false;
+		default:
+			return false;
+	}
+}
 
 /**
  *

--- a/test/samples/ts-arrow-as-const-object/expected.ts
+++ b/test/samples/ts-arrow-as-const-object/expected.ts
@@ -1,0 +1,3 @@
+const as_const = [].map(() => ({ baz } as const));
+const non_null = [].map(() => ({ baz: 1 }!));
+const satisfies = [].map(() => (({ x: 1 }) satisfies { x: number }));

--- a/test/samples/ts-arrow-as-const-object/expected.ts.map
+++ b/test/samples/ts-arrow-as-const-object/expected.ts.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": [
+    "input.js"
+  ],
+  "sourcesContent": [
+    "const as_const = [].map(() => ({ baz }) as const);\nconst non_null = [].map(() => ({ baz: 1 })!);\nconst satisfies = [].map(() => ({ x: 1 }) satisfies { x: number });\n"
+  ],
+  "mappings": "AAAA,MAAM,AAAA,QAAQ,MAAM,GAAG,UAAU,GAAG,MAAO,KAAK;AAChD,MAAM,AAAA,QAAQ,MAAM,GAAG,UAAU,GAAG,EAAE,CAAC;AACvC,MAAM,AAAA,SAAS,MAAM,GAAG,WAAU,CAAC,EAAE,CAAC,gBAAgB,CAAC,EAAE,MAAM"
+}

--- a/test/samples/ts-arrow-as-const-object/input.ts
+++ b/test/samples/ts-arrow-as-const-object/input.ts
@@ -1,0 +1,3 @@
+const as_const = [].map(() => ({ baz }) as const);
+const non_null = [].map(() => ({ baz: 1 })!);
+const satisfies = [].map(() => ({ x: 1 }) satisfies { x: number });


### PR DESCRIPTION
Fixes #121