### PR TITLE
fix: keep `=>` on the same line as a multiline arrow return type

### DIFF
--- a/.changeset/arrow-function-multiline-return-type.md
+++ b/.changeset/arrow-function-multiline-return-type.md
@@ -1,0 +1,5 @@
+---
+'esrap': patch
+---
+
+Fix invalid output (`Unexpected newline before "=>"`) when an arrow function has a return type annotation that wraps onto multiple lines

--- a/.changeset/arrow-function-multiline-return-type.md
+++ b/.changeset/arrow-function-multiline-return-type.md
@@ -2,4 +2,4 @@
 'esrap': patch
 ---
 
-Fix invalid output (`Unexpected newline before "=>"`) when an arrow function has a return type annotation that wraps onto multiple lines
+fix: keep `=>` on same line when return type annotation wraps onto multiple lines

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -2106,12 +2106,12 @@ export default (options = {}) => {
 		},
 
 		TSUnionType(node, context) {
-			// no closing bracket follows, so don't leave a trailing newline
+			// no trailing newline, so a following `=>` stays on the same line
 			sequence(context, node.types, node.loc?.end ?? null, false, ' |', false);
 		},
 
 		TSIntersectionType(node, context) {
-			// no closing bracket follows, so don't leave a trailing newline
+			// no trailing newline, so a following `=>` stays on the same line
 			sequence(context, node.types, node.loc?.end ?? null, false, ' &', false);
 		},
 

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -360,7 +360,7 @@ export default (options = {}) => {
 	 * @param {{ line: number, column: number }} until
 	 * @param {boolean} pad
 	 */
-	function sequence(context, nodes, until, pad, separator = ',') {
+	function sequence(context, nodes, until, pad, separator = ',', trailing_newline = true) {
 		let multiline = false;
 		let length = -1;
 
@@ -426,7 +426,7 @@ export default (options = {}) => {
 
 		if (multiline) {
 			context.dedent();
-			context.newline();
+			if (trailing_newline) context.newline();
 		} else if (pad && length > 0) {
 			context.write(' ');
 		}
@@ -2106,11 +2106,13 @@ export default (options = {}) => {
 		},
 
 		TSUnionType(node, context) {
-			sequence(context, node.types, node.loc?.end ?? null, false, ' |');
+			// no closing bracket follows, so don't leave a trailing newline
+			sequence(context, node.types, node.loc?.end ?? null, false, ' |', false);
 		},
 
 		TSIntersectionType(node, context) {
-			sequence(context, node.types, node.loc?.end ?? null, false, ' &');
+			// no closing bracket follows, so don't leave a trailing newline
+			sequence(context, node.types, node.loc?.end ?? null, false, ' &', false);
 		},
 
 		TSInferType(node, context) {

--- a/test/arrow-function-return-type.test.js
+++ b/test/arrow-function-return-type.test.js
@@ -1,0 +1,19 @@
+// @ts-check
+
+import { expect, test } from 'vitest';
+import { acornParse } from './common.js';
+import { print } from '../src/index.js';
+import ts from '../src/languages/ts/index.js';
+
+// a long return type must not push `=>` onto its own line (no LineTerminator before `=>`)
+test('does not emit a line terminator before `=>` for a long arrow return type', () => {
+	const input =
+		"const toNode = (kind: string): { kind: 'logical'; value: string } | { kind: 'binary'; value: number } => " +
+		"(kind === 'and' ? { kind: 'logical', value: kind } : { kind: 'binary', value: 1 });";
+
+	const { ast } = acornParse(input);
+	const { code } = print(ast, ts());
+
+	expect(code).not.toMatch(/[\r\n]\s*=>/);
+	expect(() => acornParse(code)).not.toThrow();
+});

--- a/test/samples/ts-arrow-function-long-return-type/expected.ts
+++ b/test/samples/ts-arrow-function-long-return-type/expected.ts
@@ -1,0 +1,5 @@
+const toNode = (kind: string): 
+	{ kind: 'logical'; value: string } |
+	{ kind: 'binary'; value: number } => kind === 'and'
+	? { kind: 'logical', value: kind }
+	: { kind: 'binary', value: 1 };

--- a/test/samples/ts-arrow-function-long-return-type/expected.ts.map
+++ b/test/samples/ts-arrow-function-long-return-type/expected.ts.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": [
+    "input.js"
+  ],
+  "sourcesContent": [
+    "const toNode = (\n\tkind: string\n): { kind: 'logical'; value: string } | { kind: 'binary'; value: number } =>\n\tkind === 'and' ? { kind: 'logical', value: kind } : { kind: 'binary', value: 1 };\n"
+  ],
+  "mappings": "AAAA,MAAM,AAAA,MAAM,IACX,IAAY,EAAN,MAAM;GACR,IAAI,EAAE,SAAS,EAAE,KAAK,EAAE,MAAM;GAAO,IAAI,EAAE,QAAQ,EAAE,KAAK,EAAE,MAAM,MACtE,IAAI,KAAK,KAAK;KAAK,IAAI,EAAE,SAAS,EAAE,KAAK,EAAE,IAAI;KAAO,IAAI,EAAE,QAAQ,EAAE,KAAK,EAAE,CAAC"
+}

--- a/test/samples/ts-arrow-function-long-return-type/input.ts
+++ b/test/samples/ts-arrow-function-long-return-type/input.ts
@@ -1,0 +1,4 @@
+const toNode = (
+	kind: string
+): { kind: 'logical'; value: string } | { kind: 'binary'; value: number } =>
+	kind === 'and' ? { kind: 'logical', value: kind } : { kind: 'binary', value: 1 };


### PR DESCRIPTION
A wrapped multiline return type put `=>` on its own line, which is a syntax error (ArrowParameters [no LineTerminator here] =>):

```ts
 // before
 const toNode = (kind: string):
     { kind: 'logical'; value: string } |
     { kind: 'binary'; value: number }
  => ...

 // after
 const toNode = (kind: string):
     { kind: 'logical'; value: string } |
     { kind: 'binary'; value: number } => ...
```

Union/intersection types have no closing bracket, so they no longer emit the trailing newline that `sequence()` adds for multiline blocks.