### PR TITLE
fix: add parens for `as`/`satisfies` inside unary and `**`/binary operands

### DIFF
--- a/.changeset/cool-eels-arrive.md
+++ b/.changeset/cool-eels-arrive.md
@@ -1,0 +1,5 @@
+---
+'esrap': patch
+---
+
+fix: add parentheses for `as`/`satisfies` expressions inside unary and `**`/binary operands

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -25,7 +25,6 @@ export const EXPRESSIONS_PRECEDENCE = {
 	ImportExpression: 19,
 	NewExpression: 19,
 	Literal: 18,
-	TSSatisfiesExpression: 18,
 	TSInstantiationExpression: 18,
 	TSNonNullExpression: 18,
 	TSTypeAssertion: 18,
@@ -33,11 +32,13 @@ export const EXPRESSIONS_PRECEDENCE = {
 	ClassExpression: 17,
 	FunctionExpression: 17,
 	ObjectExpression: 17,
-	TSAsExpression: 16,
 	UpdateExpression: 16,
 	UnaryExpression: 15,
 	BinaryExpression: 14,
-	LogicalExpression: 13,
+	// `as`/`satisfies` sit between binary and logical operators
+	TSAsExpression: 13,
+	TSSatisfiesExpression: 13,
+	LogicalExpression: 12,
 	ConditionalExpression: 4,
 	ArrowFunctionExpression: 3,
 	AssignmentExpression: 3,
@@ -2241,7 +2242,16 @@ export default (options = {}) => {
 		},
 
 		TSNonNullExpression(node, context) {
-			context.visit(node.expression);
+			// operator expressions can't take a postfix `!` directly: `(0 as number)!`, `(await x)!`
+			if (
+				EXPRESSIONS_PRECEDENCE[node.expression.type] < EXPRESSIONS_PRECEDENCE.TSNonNullExpression
+			) {
+				context.write('(');
+				context.visit(node.expression);
+				context.write(')');
+			} else {
+				context.visit(node.expression);
+			}
 			context.write('!');
 		},
 
@@ -2354,6 +2364,11 @@ function arrow_concise_body_needs_wrap(body) {
  */
 function needs_parens(node, parent, is_right) {
 	if (node.type === 'PrivateIdentifier') return false;
+
+	if (!is_right && (node.type === 'TSAsExpression' || node.type === 'TSSatisfiesExpression')) {
+		// `**` would be invalid, `&`/`|` would be swallowed into the trailing type
+		return parent.operator === '**' || parent.operator === '&' || parent.operator === '|';
+	}
 
 	// special case where logical expressions and coalesce expressions cannot be mixed,
 	// either of them need to be wrapped with parentheses

--- a/test/samples/ts-arrow-as-const-object/expected.ts
+++ b/test/samples/ts-arrow-as-const-object/expected.ts
@@ -1,3 +1,3 @@
 const as_const = [].map(() => ({ baz } as const));
-const non_null = [].map(() => ({ baz: 1 }!));
-const satisfies = [].map(() => (({ x: 1 }) satisfies { x: number }));
+const non_null = [].map(() => (({ baz: 1 })!));
+const satisfies = [].map(() => ({ x: 1 } satisfies { x: number }));

--- a/test/samples/ts-arrow-as-const-object/expected.ts.map
+++ b/test/samples/ts-arrow-as-const-object/expected.ts.map
@@ -7,5 +7,5 @@
   "sourcesContent": [
     "const as_const = [].map(() => ({ baz }) as const);\nconst non_null = [].map(() => ({ baz: 1 })!);\nconst satisfies = [].map(() => ({ x: 1 }) satisfies { x: number });\n"
   ],
-  "mappings": "AAAA,MAAM,AAAA,QAAQ,MAAM,GAAG,UAAU,GAAG,MAAO,KAAK;AAChD,MAAM,AAAA,QAAQ,MAAM,GAAG,UAAU,GAAG,EAAE,CAAC;AACvC,MAAM,AAAA,SAAS,MAAM,GAAG,WAAU,CAAC,EAAE,CAAC,gBAAgB,CAAC,EAAE,MAAM"
+  "mappings": "AAAA,MAAM,AAAA,QAAQ,MAAM,GAAG,UAAU,GAAG,MAAO,KAAK;AAChD,MAAM,AAAA,QAAQ,MAAM,GAAG,WAAU,GAAG,EAAE,CAAC;AACvC,MAAM,AAAA,SAAS,MAAM,GAAG,UAAU,CAAC,EAAE,CAAC,eAAgB,CAAC,EAAE,MAAM"
 }

--- a/test/samples/ts-as-precedence/expected.ts
+++ b/test/samples/ts-as-precedence/expected.ts
@@ -1,0 +1,26 @@
+!(0 as number);
+-(0 as number);
+~(0 as number);
+typeof (0 as any);
+void (0 as any);
+1 + (0 as number);
+2 * (0 as number);
+1 ** (0n as any);
+1 & (0 as number);
+(0 as number) ** 2;
+(0 as number) & 1;
+(0 as number) | 1;
+0 as number + 1;
+(0 as number)!;
+a && b as C;
+a as C && b;
+!(0 satisfies number);
+1 ** (0n satisfies any);
+1 + (0 satisfies number);
+(0 satisfies number)!;
+
+async function f() {
+	await (0 as any);
+	await (0 satisfies number);
+	(await x)!;
+}

--- a/test/samples/ts-as-precedence/expected.ts.map
+++ b/test/samples/ts-as-precedence/expected.ts.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": [
+    "input.js"
+  ],
+  "sourcesContent": [
+    "!(0 as number);\n-(0 as number);\n~(0 as number);\ntypeof (0 as any);\nvoid (0 as any);\n1 + (0 as number);\n2 * (0 as number);\n1 ** (0n as any);\n1 & (0 as number);\n(0 as number) ** 2;\n(0 as number) & 1;\n(0 as number) | 1;\n(0 as number) + 1;\n(0 as number)!;\na && (b as C);\n(a as C) && b;\n!(0 satisfies number);\n1 ** (0n satisfies any);\n1 + (0 satisfies number);\n(0 satisfies number)!;\n\nasync function f() {\n\tawait (0 as any);\n\tawait (0 satisfies number);\n\t(await x)!;\n}\n"
+  ],
+  "mappings": "EAAE,CAAC,IAAI,MAAM;EACX,CAAC,IAAI,MAAM;EACX,CAAC,IAAI,MAAM;QACL,CAAC,IAAI,GAAG;MACV,CAAC,IAAI,GAAG;AACd,CAAC,IAAI,CAAC,IAAI,MAAM;AAChB,CAAC,IAAI,CAAC,IAAI,MAAM;AAChB,CAAC,KAAK,EAAE,IAAI,GAAG;AACf,CAAC,IAAI,CAAC,IAAI,MAAM;CACf,CAAC,IAAI,MAAM,KAAK,CAAC;CACjB,CAAC,IAAI,MAAM,IAAI,CAAC;CAChB,CAAC,IAAI,MAAM,IAAI,CAAC;AAChB,CAAC,IAAI,MAAM,GAAI,CAAC;CAChB,CAAC,IAAI,MAAM;AACZ,CAAC,IAAK,CAAC,IAAI,CAAC;AACX,CAAC,IAAI,CAAC,IAAK,CAAC;EACX,CAAC,WAAW,MAAM;AACpB,CAAC,KAAK,EAAE,WAAW,GAAG;AACtB,CAAC,IAAI,CAAC,WAAW,MAAM;CACtB,CAAC,WAAW,MAAM;;AAEnB,MAAM,AAAA,QAAQ,CAAC,CAAC,GAAG,CAAC;CACnB,KAAK,EAAE,CAAC,IAAI,GAAG;CACf,KAAK,EAAE,CAAC,WAAW,MAAM;EACxB,KAAK,CAAC,CAAC;AACT,CAAC"
+}

--- a/test/samples/ts-as-precedence/input.ts
+++ b/test/samples/ts-as-precedence/input.ts
@@ -1,0 +1,26 @@
+!(0 as number);
+-(0 as number);
+~(0 as number);
+typeof (0 as any);
+void (0 as any);
+1 + (0 as number);
+2 * (0 as number);
+1 ** (0n as any);
+1 & (0 as number);
+(0 as number) ** 2;
+(0 as number) & 1;
+(0 as number) | 1;
+(0 as number) + 1;
+(0 as number)!;
+a && (b as C);
+(a as C) && b;
+!(0 satisfies number);
+1 ** (0n satisfies any);
+1 + (0 satisfies number);
+(0 satisfies number)!;
+
+async function f() {
+	await (0 as any);
+	await (0 satisfies number);
+	(await x)!;
+}


### PR DESCRIPTION
close #127