### PR TITLE
fix: more bugs with parentheses

### DIFF
--- a/.changeset/paren-correctness.md
+++ b/.changeset/paren-correctness.md
@@ -5,5 +5,5 @@
 fix: preserve required parentheses in three more cases that changed meaning or produced invalid output
 
 - nested same-sign unary operators (`-(-a)` was printed as `--a`, the decrement operator; `-(--a)` as invalid `---a`)
-- parenthesized optional chains as a callee/object/tag/new (`(a?.b)()` was printed as `a?.b()`, silently changing short-circuit behavior; `new (a?.b)()` and `` (a?.b)`` `` became invalid)
+- parenthesized optional chains as a callee/object/tag/new (`(a?.b)()` was printed as `a?.b()`, silently changing short-circuit behavior; `new (a?.b)()` and ` (a?.b)` `` became invalid)
 - `await` as the left operand of `**` (`(await a) ** b` was printed as the SyntaxError `await a ** b`)

--- a/.changeset/paren-correctness.md
+++ b/.changeset/paren-correctness.md
@@ -2,8 +2,4 @@
 'esrap': patch
 ---
 
-fix: preserve required parentheses in three more cases that changed meaning or produced invalid output
-
-- nested same-sign unary operators (`-(-a)` was printed as `--a`, the decrement operator; `-(--a)` as invalid `---a`)
-- parenthesized optional chains as a callee/object/tag/new (`(a?.b)()` was printed as `a?.b()`, silently changing short-circuit behavior; `new (a?.b)()` and ` (a?.b)` `` became invalid)
-- `await` as the left operand of `**` (`(await a) ** b` was printed as the SyntaxError `await a ** b`)
+fix: preserve required parentheses that were being dropped, changing meaning or producing invalid output (nested unary operators, parenthesized optional chains, and `await` as the left operand of `**`)

--- a/.changeset/paren-correctness.md
+++ b/.changeset/paren-correctness.md
@@ -1,0 +1,9 @@
+---
+'esrap': patch
+---
+
+fix: preserve required parentheses in three more cases that changed meaning or produced invalid output
+
+- nested same-sign unary operators (`-(-a)` was printed as `--a`, the decrement operator; `-(--a)` as invalid `---a`)
+- parenthesized optional chains as a callee/object/tag/new (`(a?.b)()` was printed as `a?.b()`, silently changing short-circuit behavior; `new (a?.b)()` and `` (a?.b)`` `` became invalid)
+- `await` as the left operand of `**` (`(await a) ** b` was printed as the SyntaxError `await a ** b`)

--- a/.changeset/precedence-constants.md
+++ b/.changeset/precedence-constants.md
@@ -2,4 +2,4 @@
 'esrap': patch
 ---
 
-refactor: derive `needs_parens` precedence checks from the precedence table instead of hard-coded numbers, so they can't drift out of sync (the cause of #131)
+refactor: derive `needs_parens` precedence checks from the precedence table instead of hard-coded numbers

--- a/.changeset/precedence-constants.md
+++ b/.changeset/precedence-constants.md
@@ -1,5 +1,0 @@
----
-'esrap': patch
----
-
-refactor: derive `needs_parens` precedence checks from the precedence table instead of hard-coded numbers

--- a/.changeset/precedence-constants.md
+++ b/.changeset/precedence-constants.md
@@ -1,0 +1,5 @@
+---
+'esrap': patch
+---
+
+refactor: derive `needs_parens` precedence checks from the precedence table instead of hard-coded numbers, so they can't drift out of sync (the cause of #131)

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -46,6 +46,10 @@ export const EXPRESSIONS_PRECEDENCE = {
 	RestElement: 1
 };
 
+const UNARY_PRECEDENCE = EXPRESSIONS_PRECEDENCE.UnaryExpression;
+const BINARY_PRECEDENCE = EXPRESSIONS_PRECEDENCE.BinaryExpression;
+const LOGICAL_PRECEDENCE = EXPRESSIONS_PRECEDENCE.LogicalExpression;
+
 const OPERATOR_PRECEDENCE = {
 	'||': 2,
 	'&&': 3,
@@ -2389,12 +2393,15 @@ function needs_parens(node, parent, is_right) {
 	if (precedence !== parent_precedence) {
 		// Different node types
 		return (
-			(!is_right && precedence === 15 && parent_precedence === 14 && parent.operator === '**') ||
+			(!is_right &&
+				precedence === UNARY_PRECEDENCE &&
+				parent_precedence === BINARY_PRECEDENCE &&
+				parent.operator === '**') ||
 			precedence < parent_precedence
 		);
 	}
 
-	if (precedence !== 12 && precedence !== 14) {
+	if (precedence !== LOGICAL_PRECEDENCE && precedence !== BINARY_PRECEDENCE) {
 		// Not a `LogicalExpression` or `BinaryExpression`
 		return false;
 	}

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -580,6 +580,7 @@ export default (options = {}) => {
 			}
 
 			const needs_parens =
+				node.callee.type === 'ChainExpression' ||
 				EXPRESSIONS_PRECEDENCE[node.callee.type] < EXPRESSIONS_PRECEDENCE.CallExpression ||
 				(node.type === 'NewExpression' && has_call_expression(node.callee));
 
@@ -1440,7 +1441,10 @@ export default (options = {}) => {
 		LogicalExpression: shared['BinaryExpression|LogicalExpression'],
 
 		MemberExpression(node, context) {
-			if (EXPRESSIONS_PRECEDENCE[node.object.type] < EXPRESSIONS_PRECEDENCE.MemberExpression) {
+			if (
+				node.object.type === 'ChainExpression' ||
+				EXPRESSIONS_PRECEDENCE[node.object.type] < EXPRESSIONS_PRECEDENCE.MemberExpression
+			) {
 				context.write('(');
 				context.visit(node.object);
 				context.write(')');
@@ -1638,7 +1642,13 @@ export default (options = {}) => {
 		},
 
 		TaggedTemplateExpression(node, context) {
-			context.visit(node.tag);
+			if (node.tag.type === 'ChainExpression') {
+				context.write('(');
+				context.visit(node.tag);
+				context.write(')');
+			} else {
+				context.visit(node.tag);
+			}
 			context.visit(node.quasi);
 		},
 
@@ -1710,6 +1720,14 @@ export default (options = {}) => {
 			context.write(node.operator);
 
 			if (node.operator.length > 1) {
+				context.write(' ');
+			} else if (
+				(node.operator === '+' || node.operator === '-') &&
+				((node.argument.type === 'UnaryExpression' && node.argument.operator === node.operator) ||
+					(node.argument.type === 'UpdateExpression' &&
+						node.argument.prefix &&
+						node.argument.operator[0] === node.operator))
+			) {
 				context.write(' ');
 			}
 
@@ -2394,7 +2412,7 @@ function needs_parens(node, parent, is_right) {
 		// Different node types
 		return (
 			(!is_right &&
-				precedence === UNARY_PRECEDENCE &&
+				(precedence === UNARY_PRECEDENCE || node.type === 'AwaitExpression') &&
 				parent_precedence === BINARY_PRECEDENCE &&
 				parent.operator === '**') ||
 			precedence < parent_precedence

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -511,23 +511,11 @@ export default (options = {}) => {
 			// 	// Avoids confusion in `for` loops initializers
 			// 	chunks.write('(');
 			// }
-			if (needs_parens(node.left, node, false)) {
-				context.write('(');
-				context.visit(node.left);
-				context.write(')');
-			} else {
-				context.visit(node.left);
-			}
+			visit_parenthesized(context, node.left, operand_needs_parens(node.left, node, false));
 
 			context.write(` ${node.operator} `);
 
-			if (needs_parens(node.right, node, true)) {
-				context.write('(');
-				context.visit(node.right);
-				context.write(')');
-			} else {
-				context.visit(node.right);
-			}
+			visit_parenthesized(context, node.right, operand_needs_parens(node.right, node, true));
 		},
 
 		/**
@@ -575,18 +563,12 @@ export default (options = {}) => {
 				write_keyword(context, node, 'new', ' ');
 			}
 
-			const needs_parens =
+			const needs =
 				node.callee.type === 'ChainExpression' ||
 				EXPRESSIONS_PRECEDENCE[node.callee.type] < EXPRESSIONS_PRECEDENCE.CallExpression ||
 				(node.type === 'NewExpression' && has_call_expression(node.callee));
 
-			if (needs_parens) {
-				context.write('(');
-				context.visit(node.callee);
-				context.write(')');
-			} else {
-				context.visit(node.callee);
-			}
+			visit_parenthesized(context, node.callee, needs);
 
 			if (/** @type {TSESTree.CallExpression} */ (node).optional) {
 				context.write('?.');
@@ -1437,17 +1419,11 @@ export default (options = {}) => {
 		LogicalExpression: shared['BinaryExpression|LogicalExpression'],
 
 		MemberExpression(node, context) {
-			const needs_parens =
+			const needs =
 				node.object.type === 'ChainExpression' ||
 				EXPRESSIONS_PRECEDENCE[node.object.type] < EXPRESSIONS_PRECEDENCE.MemberExpression;
 
-			if (needs_parens) {
-				context.write('(');
-				context.visit(node.object);
-				context.write(')');
-			} else {
-				context.visit(node.object);
-			}
+			visit_parenthesized(context, node.object, needs);
 
 			if (node.computed) {
 				if (node.optional) {
@@ -2209,16 +2185,10 @@ export default (options = {}) => {
 
 		TSAsExpression(node, context) {
 			if (node.expression) {
-				const needs_parens =
+				const needs =
 					EXPRESSIONS_PRECEDENCE[node.expression.type] < EXPRESSIONS_PRECEDENCE.TSAsExpression;
 
-				if (needs_parens) {
-					context.write('(');
-					context.visit(node.expression);
-					context.write(')');
-				} else {
-					context.visit(node.expression);
-				}
+				visit_parenthesized(context, node.expression, needs);
 			}
 			context.write(' as ');
 			context.visit(node.typeAnnotation);
@@ -2264,15 +2234,10 @@ export default (options = {}) => {
 
 		TSNonNullExpression(node, context) {
 			// operator expressions can't take a postfix `!` directly: `(0 as number)!`, `(await x)!`
-			if (
-				EXPRESSIONS_PRECEDENCE[node.expression.type] < EXPRESSIONS_PRECEDENCE.TSNonNullExpression
-			) {
-				context.write('(');
-				context.visit(node.expression);
-				context.write(')');
-			} else {
-				context.visit(node.expression);
-			}
+			const needs =
+				EXPRESSIONS_PRECEDENCE[node.expression.type] < EXPRESSIONS_PRECEDENCE.TSNonNullExpression;
+
+			visit_parenthesized(context, node.expression, needs);
 			context.write('!');
 		},
 
@@ -2313,17 +2278,11 @@ export default (options = {}) => {
 
 		TSSatisfiesExpression(node, context) {
 			if (node.expression) {
-				const needs_parens =
+				const needs =
 					EXPRESSIONS_PRECEDENCE[node.expression.type] <
 					EXPRESSIONS_PRECEDENCE.TSSatisfiesExpression;
 
-				if (needs_parens) {
-					context.write('(');
-					context.visit(node.expression);
-					context.write(')');
-				} else {
-					context.visit(node.expression);
-				}
+				visit_parenthesized(context, node.expression, needs);
 			}
 			context.write(' satisfies ');
 			context.visit(node.typeAnnotation);
@@ -2383,7 +2342,7 @@ function arrow_concise_body_needs_wrap(body) {
  * @param {boolean} is_right
  * @returns
  */
-function needs_parens(node, parent, is_right) {
+function operand_needs_parens(node, parent, is_right) {
 	if (node.type === 'PrivateIdentifier') return false;
 
 	if (!is_right && (node.type === 'TSAsExpression' || node.type === 'TSSatisfiesExpression')) {
@@ -2428,6 +2387,21 @@ function needs_parens(node, parent, is_right) {
 	return OPERATOR_PRECEDENCE[operator] < OPERATOR_PRECEDENCE[parent.operator];
 }
 
+/**
+ * @param {Context} context
+ * @param {TSESTree.Node} node
+ * @param {boolean} needs
+ */
+function visit_parenthesized(context, node, needs) {
+	if (needs) {
+		context.write('(');
+		context.visit(node);
+		context.write(')');
+	} else {
+		context.visit(node);
+	}
+}
+
 /** @param {TSESTree.Node} node */
 function has_call_expression(node) {
 	while (node) {
@@ -2439,6 +2413,7 @@ function has_call_expression(node) {
 			return false;
 		}
 	}
+	return false;
 }
 
 /**

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -511,11 +511,11 @@ export default (options = {}) => {
 			// 	// Avoids confusion in `for` loops initializers
 			// 	chunks.write('(');
 			// }
-			visit_parenthesized(context, node.left, operand_needs_parens(node.left, node, false));
+			maybe_wrap(context, node.left, operand_needs_wrap(node.left, node, false));
 
 			context.write(` ${node.operator} `);
 
-			visit_parenthesized(context, node.right, operand_needs_parens(node.right, node, true));
+			maybe_wrap(context, node.right, operand_needs_wrap(node.right, node, true));
 		},
 
 		/**
@@ -563,12 +563,12 @@ export default (options = {}) => {
 				write_keyword(context, node, 'new', ' ');
 			}
 
-			const needs =
+			const wrap =
 				node.callee.type === 'ChainExpression' ||
 				EXPRESSIONS_PRECEDENCE[node.callee.type] < EXPRESSIONS_PRECEDENCE.CallExpression ||
 				(node.type === 'NewExpression' && has_call_expression(node.callee));
 
-			visit_parenthesized(context, node.callee, needs);
+			maybe_wrap(context, node.callee, wrap);
 
 			if (/** @type {TSESTree.CallExpression} */ (node).optional) {
 				context.write('?.');
@@ -909,7 +909,6 @@ export default (options = {}) => {
 			}
 
 			context.write('(');
-
 			sequence(
 				context,
 				// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
@@ -936,7 +935,6 @@ export default (options = {}) => {
 			if (node.typeParameters) context.visit(node.typeParameters);
 
 			context.write('(');
-
 			sequence(
 				context,
 				// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
@@ -947,7 +945,6 @@ export default (options = {}) => {
 					null,
 				false
 			);
-
 			context.write(') => ');
 
 			// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
@@ -994,13 +991,7 @@ export default (options = {}) => {
 
 			context.write(' => ');
 
-			if (arrow_concise_body_needs_wrap(node.body)) {
-				context.write('(');
-				context.visit(node.body);
-				context.write(')');
-			} else {
-				context.visit(node.body);
-			}
+			maybe_wrap(context, node.body, arrow_concise_body_needs_wrap(node.body));
 		},
 
 		AssignmentExpression(node, context) {
@@ -1059,13 +1050,10 @@ export default (options = {}) => {
 		ClassExpression: shared['ClassDeclaration|ClassExpression'],
 
 		ConditionalExpression(node, context) {
-			if (EXPRESSIONS_PRECEDENCE[node.test.type] > EXPRESSIONS_PRECEDENCE.ConditionalExpression) {
-				context.visit(node.test);
-			} else {
-				context.write('(');
-				context.visit(node.test);
-				context.write(')');
-			}
+			const wrap =
+				EXPRESSIONS_PRECEDENCE[node.test.type] <= EXPRESSIONS_PRECEDENCE.ConditionalExpression;
+
+			maybe_wrap(context, node.test, wrap);
 
 			const consequent = context.new();
 			const alternate = context.new();
@@ -1223,20 +1211,14 @@ export default (options = {}) => {
 		},
 
 		ExpressionStatement(node, context) {
-			if (
+			// wrap when a leading `{`/`function` would otherwise be parsed as a block/declaration
+			const wrap =
 				node.expression.type === 'ObjectExpression' ||
 				(node.expression.type === 'AssignmentExpression' &&
 					node.expression.left.type === 'ObjectPattern') ||
-				node.expression.type === 'FunctionExpression'
-			) {
-				// is an AssignmentExpression to an ObjectPattern
-				context.write('(');
-				context.visit(node.expression);
-				context.write(');');
-				return;
-			}
+				node.expression.type === 'FunctionExpression';
 
-			context.visit(node.expression);
+			maybe_wrap(context, node.expression, wrap);
 			context.write(';');
 		},
 
@@ -1419,11 +1401,11 @@ export default (options = {}) => {
 		LogicalExpression: shared['BinaryExpression|LogicalExpression'],
 
 		MemberExpression(node, context) {
-			const needs =
+			const wrap =
 				node.object.type === 'ChainExpression' ||
 				EXPRESSIONS_PRECEDENCE[node.object.type] < EXPRESSIONS_PRECEDENCE.MemberExpression;
 
-			visit_parenthesized(context, node.object, needs);
+			maybe_wrap(context, node.object, wrap);
 
 			if (node.computed) {
 				if (node.optional) {
@@ -1464,9 +1446,7 @@ export default (options = {}) => {
 
 		// @ts-expect-error this isn't a real node type, but Acorn produces it
 		ParenthesizedExpression(node, context) {
-			context.write('(');
-			context.visit(node.expression);
-			context.write(')');
+			maybe_wrap(context, node.expression, true);
 		},
 
 		PrivateIdentifier(node, context) {
@@ -1615,13 +1595,7 @@ export default (options = {}) => {
 		},
 
 		TaggedTemplateExpression(node, context) {
-			if (node.tag.type === 'ChainExpression') {
-				context.write('(');
-				context.visit(node.tag);
-				context.write(')');
-			} else {
-				context.visit(node.tag);
-			}
+			maybe_wrap(context, node.tag, node.tag.type === 'ChainExpression');
 			context.visit(node.quasi);
 		},
 
@@ -1704,13 +1678,10 @@ export default (options = {}) => {
 				context.write(' ');
 			}
 
-			if (EXPRESSIONS_PRECEDENCE[node.argument.type] < EXPRESSIONS_PRECEDENCE.UnaryExpression) {
-				context.write('(');
-				context.visit(node.argument);
-				context.write(')');
-			} else {
-				context.visit(node.argument);
-			}
+			const wrap =
+				EXPRESSIONS_PRECEDENCE[node.argument.type] < EXPRESSIONS_PRECEDENCE.UnaryExpression;
+
+			maybe_wrap(context, node.argument, wrap);
 		},
 
 		UpdateExpression(node, context) {
@@ -1946,13 +1917,10 @@ export default (options = {}) => {
 			context.write('<');
 			context.visit(node.typeAnnotation);
 			context.write('>');
-			if (EXPRESSIONS_PRECEDENCE[node.expression.type] < EXPRESSIONS_PRECEDENCE.TSTypeAssertion) {
-				context.write('(');
-				context.visit(node.expression);
-				context.write(')');
-			} else {
-				context.visit(node.expression);
-			}
+			const wrap =
+				EXPRESSIONS_PRECEDENCE[node.expression.type] < EXPRESSIONS_PRECEDENCE.TSTypeAssertion;
+
+			maybe_wrap(context, node.expression, wrap);
 		},
 
 		TSTypeParameterInstantiation(node, context) {
@@ -2071,7 +2039,6 @@ export default (options = {}) => {
 			context.visit(node.key);
 
 			context.write('(');
-
 			sequence(
 				context,
 				// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
@@ -2185,10 +2152,10 @@ export default (options = {}) => {
 
 		TSAsExpression(node, context) {
 			if (node.expression) {
-				const needs =
+				const wrap =
 					EXPRESSIONS_PRECEDENCE[node.expression.type] < EXPRESSIONS_PRECEDENCE.TSAsExpression;
 
-				visit_parenthesized(context, node.expression, needs);
+				maybe_wrap(context, node.expression, wrap);
 			}
 			context.write(' as ');
 			context.visit(node.typeAnnotation);
@@ -2234,10 +2201,10 @@ export default (options = {}) => {
 
 		TSNonNullExpression(node, context) {
 			// operator expressions can't take a postfix `!` directly: `(0 as number)!`, `(await x)!`
-			const needs =
+			const wrap =
 				EXPRESSIONS_PRECEDENCE[node.expression.type] < EXPRESSIONS_PRECEDENCE.TSNonNullExpression;
 
-			visit_parenthesized(context, node.expression, needs);
+			maybe_wrap(context, node.expression, wrap);
 			context.write('!');
 		},
 
@@ -2271,18 +2238,16 @@ export default (options = {}) => {
 
 		//@ts-expect-error I don't know why, but this is relied upon in the tests, but doesn't exist in the TSESTree types
 		TSParenthesizedType(node, context) {
-			context.write('(');
-			context.visit(node.typeAnnotation);
-			context.write(')');
+			maybe_wrap(context, node.typeAnnotation, true);
 		},
 
 		TSSatisfiesExpression(node, context) {
 			if (node.expression) {
-				const needs =
+				const wrap =
 					EXPRESSIONS_PRECEDENCE[node.expression.type] <
 					EXPRESSIONS_PRECEDENCE.TSSatisfiesExpression;
 
-				visit_parenthesized(context, node.expression, needs);
+				maybe_wrap(context, node.expression, wrap);
 			}
 			context.write(' satisfies ');
 			context.visit(node.typeAnnotation);
@@ -2342,7 +2307,7 @@ function arrow_concise_body_needs_wrap(body) {
  * @param {boolean} is_right
  * @returns
  */
-function operand_needs_parens(node, parent, is_right) {
+function operand_needs_wrap(node, parent, is_right) {
 	if (node.type === 'PrivateIdentifier') return false;
 
 	if (!is_right && (node.type === 'TSAsExpression' || node.type === 'TSSatisfiesExpression')) {
@@ -2390,10 +2355,10 @@ function operand_needs_parens(node, parent, is_right) {
 /**
  * @param {Context} context
  * @param {TSESTree.Node} node
- * @param {boolean} needs
+ * @param {boolean} wrap
  */
-function visit_parenthesized(context, node, needs) {
-	if (needs) {
+function maybe_wrap(context, node, wrap) {
+	if (wrap) {
 		context.write('(');
 		context.visit(node);
 		context.write(')');

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -2402,16 +2402,15 @@ function needs_parens(node, parent, is_right) {
 		return true;
 	}
 
-	const precedence = EXPRESSIONS_PRECEDENCE[node.type];
-	const parent_precedence = EXPRESSIONS_PRECEDENCE[parent.type];
-
 	// `**` can't take a unary/await left operand: `-2 ** 2`, `await x ** 2` are syntax errors
 	const unary_base_of_pow =
 		!is_right &&
 		parent.operator === '**' &&
 		(node.type === 'UnaryExpression' || node.type === 'AwaitExpression');
-
 	if (unary_base_of_pow) return true;
+
+	const precedence = EXPRESSIONS_PRECEDENCE[node.type];
+	const parent_precedence = EXPRESSIONS_PRECEDENCE[parent.type];
 	if (precedence !== parent_precedence) return precedence < parent_precedence;
 
 	const operator = /** @type {TSESTree.BinaryExpression} */ (node).operator;

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -945,7 +945,9 @@ export default (options = {}) => {
 					null,
 				false
 			);
-			context.write(') => ');
+			context.write(')');
+
+			context.write(' => ');
 
 			// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
 			context.visit(node.typeAnnotation?.typeAnnotation ?? node.returnType?.typeAnnotation);

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -511,23 +511,11 @@ export default (options = {}) => {
 			// 	// Avoids confusion in `for` loops initializers
 			// 	chunks.write('(');
 			// }
-			if (needs_parens(node.left, node, false)) {
-				context.write('(');
-				context.visit(node.left);
-				context.write(')');
-			} else {
-				context.visit(node.left);
-			}
+			maybe_wrap(context, node.left, operand_needs_wrap(node.left, node, false));
 
 			context.write(` ${node.operator} `);
 
-			if (needs_parens(node.right, node, true)) {
-				context.write('(');
-				context.visit(node.right);
-				context.write(')');
-			} else {
-				context.visit(node.right);
-			}
+			maybe_wrap(context, node.right, operand_needs_wrap(node.right, node, true));
 		},
 
 		/**
@@ -575,18 +563,11 @@ export default (options = {}) => {
 				write_keyword(context, node, 'new', ' ');
 			}
 
-			const needs_parens =
+			const wrap =
 				node.callee.type === 'ChainExpression' ||
 				EXPRESSIONS_PRECEDENCE[node.callee.type] < EXPRESSIONS_PRECEDENCE.CallExpression ||
 				(node.type === 'NewExpression' && has_call_expression(node.callee));
-
-			if (needs_parens) {
-				context.write('(');
-				context.visit(node.callee);
-				context.write(')');
-			} else {
-				context.visit(node.callee);
-			}
+			maybe_wrap(context, node.callee, wrap);
 
 			if (/** @type {TSESTree.CallExpression} */ (node).optional) {
 				context.write('?.');
@@ -927,7 +908,6 @@ export default (options = {}) => {
 			}
 
 			context.write('(');
-
 			sequence(
 				context,
 				// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
@@ -954,7 +934,6 @@ export default (options = {}) => {
 			if (node.typeParameters) context.visit(node.typeParameters);
 
 			context.write('(');
-
 			sequence(
 				context,
 				// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
@@ -965,8 +944,9 @@ export default (options = {}) => {
 					null,
 				false
 			);
+			context.write(')');
 
-			context.write(') => ');
+			context.write(' => ');
 
 			// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
 			context.visit(node.typeAnnotation?.typeAnnotation ?? node.returnType?.typeAnnotation);
@@ -1012,13 +992,7 @@ export default (options = {}) => {
 
 			context.write(' => ');
 
-			if (arrow_concise_body_needs_wrap(node.body)) {
-				context.write('(');
-				context.visit(node.body);
-				context.write(')');
-			} else {
-				context.visit(node.body);
-			}
+			maybe_wrap(context, node.body, arrow_concise_body_needs_wrap(node.body));
 		},
 
 		AssignmentExpression(node, context) {
@@ -1077,13 +1051,9 @@ export default (options = {}) => {
 		ClassExpression: shared['ClassDeclaration|ClassExpression'],
 
 		ConditionalExpression(node, context) {
-			if (EXPRESSIONS_PRECEDENCE[node.test.type] > EXPRESSIONS_PRECEDENCE.ConditionalExpression) {
-				context.visit(node.test);
-			} else {
-				context.write('(');
-				context.visit(node.test);
-				context.write(')');
-			}
+			const wrap =
+				EXPRESSIONS_PRECEDENCE[node.test.type] <= EXPRESSIONS_PRECEDENCE.ConditionalExpression;
+			maybe_wrap(context, node.test, wrap);
 
 			const consequent = context.new();
 			const alternate = context.new();
@@ -1241,20 +1211,13 @@ export default (options = {}) => {
 		},
 
 		ExpressionStatement(node, context) {
-			if (
+			// wrap when a leading `{`/`function` would otherwise be parsed as a block/declaration
+			const wrap =
 				node.expression.type === 'ObjectExpression' ||
 				(node.expression.type === 'AssignmentExpression' &&
 					node.expression.left.type === 'ObjectPattern') ||
-				node.expression.type === 'FunctionExpression'
-			) {
-				// is an AssignmentExpression to an ObjectPattern
-				context.write('(');
-				context.visit(node.expression);
-				context.write(');');
-				return;
-			}
-
-			context.visit(node.expression);
+				node.expression.type === 'FunctionExpression';
+			maybe_wrap(context, node.expression, wrap);
 			context.write(';');
 		},
 
@@ -1437,17 +1400,10 @@ export default (options = {}) => {
 		LogicalExpression: shared['BinaryExpression|LogicalExpression'],
 
 		MemberExpression(node, context) {
-			const needs_parens =
+			const wrap =
 				node.object.type === 'ChainExpression' ||
 				EXPRESSIONS_PRECEDENCE[node.object.type] < EXPRESSIONS_PRECEDENCE.MemberExpression;
-
-			if (needs_parens) {
-				context.write('(');
-				context.visit(node.object);
-				context.write(')');
-			} else {
-				context.visit(node.object);
-			}
+			maybe_wrap(context, node.object, wrap);
 
 			if (node.computed) {
 				if (node.optional) {
@@ -1488,9 +1444,7 @@ export default (options = {}) => {
 
 		// @ts-expect-error this isn't a real node type, but Acorn produces it
 		ParenthesizedExpression(node, context) {
-			context.write('(');
-			context.visit(node.expression);
-			context.write(')');
+			maybe_wrap(context, node.expression, true);
 		},
 
 		PrivateIdentifier(node, context) {
@@ -1639,13 +1593,7 @@ export default (options = {}) => {
 		},
 
 		TaggedTemplateExpression(node, context) {
-			if (node.tag.type === 'ChainExpression') {
-				context.write('(');
-				context.visit(node.tag);
-				context.write(')');
-			} else {
-				context.visit(node.tag);
-			}
+			maybe_wrap(context, node.tag, node.tag.type === 'ChainExpression');
 			context.visit(node.quasi);
 		},
 
@@ -1728,13 +1676,9 @@ export default (options = {}) => {
 				context.write(' ');
 			}
 
-			if (EXPRESSIONS_PRECEDENCE[node.argument.type] < EXPRESSIONS_PRECEDENCE.UnaryExpression) {
-				context.write('(');
-				context.visit(node.argument);
-				context.write(')');
-			} else {
-				context.visit(node.argument);
-			}
+			const wrap =
+				EXPRESSIONS_PRECEDENCE[node.argument.type] < EXPRESSIONS_PRECEDENCE.UnaryExpression;
+			maybe_wrap(context, node.argument, wrap);
 		},
 
 		UpdateExpression(node, context) {
@@ -1970,13 +1914,9 @@ export default (options = {}) => {
 			context.write('<');
 			context.visit(node.typeAnnotation);
 			context.write('>');
-			if (EXPRESSIONS_PRECEDENCE[node.expression.type] < EXPRESSIONS_PRECEDENCE.TSTypeAssertion) {
-				context.write('(');
-				context.visit(node.expression);
-				context.write(')');
-			} else {
-				context.visit(node.expression);
-			}
+			const wrap =
+				EXPRESSIONS_PRECEDENCE[node.expression.type] < EXPRESSIONS_PRECEDENCE.TSTypeAssertion;
+			maybe_wrap(context, node.expression, wrap);
 		},
 
 		TSTypeParameterInstantiation(node, context) {
@@ -2095,7 +2035,6 @@ export default (options = {}) => {
 			context.visit(node.key);
 
 			context.write('(');
-
 			sequence(
 				context,
 				// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
@@ -2209,16 +2148,9 @@ export default (options = {}) => {
 
 		TSAsExpression(node, context) {
 			if (node.expression) {
-				const needs_parens =
+				const wrap =
 					EXPRESSIONS_PRECEDENCE[node.expression.type] < EXPRESSIONS_PRECEDENCE.TSAsExpression;
-
-				if (needs_parens) {
-					context.write('(');
-					context.visit(node.expression);
-					context.write(')');
-				} else {
-					context.visit(node.expression);
-				}
+				maybe_wrap(context, node.expression, wrap);
 			}
 			context.write(' as ');
 			context.visit(node.typeAnnotation);
@@ -2264,15 +2196,9 @@ export default (options = {}) => {
 
 		TSNonNullExpression(node, context) {
 			// operator expressions can't take a postfix `!` directly: `(0 as number)!`, `(await x)!`
-			if (
-				EXPRESSIONS_PRECEDENCE[node.expression.type] < EXPRESSIONS_PRECEDENCE.TSNonNullExpression
-			) {
-				context.write('(');
-				context.visit(node.expression);
-				context.write(')');
-			} else {
-				context.visit(node.expression);
-			}
+			const wrap =
+				EXPRESSIONS_PRECEDENCE[node.expression.type] < EXPRESSIONS_PRECEDENCE.TSNonNullExpression;
+			maybe_wrap(context, node.expression, wrap);
 			context.write('!');
 		},
 
@@ -2306,24 +2232,15 @@ export default (options = {}) => {
 
 		//@ts-expect-error I don't know why, but this is relied upon in the tests, but doesn't exist in the TSESTree types
 		TSParenthesizedType(node, context) {
-			context.write('(');
-			context.visit(node.typeAnnotation);
-			context.write(')');
+			maybe_wrap(context, node.typeAnnotation, true);
 		},
 
 		TSSatisfiesExpression(node, context) {
 			if (node.expression) {
-				const needs_parens =
+				const wrap =
 					EXPRESSIONS_PRECEDENCE[node.expression.type] <
 					EXPRESSIONS_PRECEDENCE.TSSatisfiesExpression;
-
-				if (needs_parens) {
-					context.write('(');
-					context.visit(node.expression);
-					context.write(')');
-				} else {
-					context.visit(node.expression);
-				}
+				maybe_wrap(context, node.expression, wrap);
 			}
 			context.write(' satisfies ');
 			context.visit(node.typeAnnotation);
@@ -2383,7 +2300,7 @@ function arrow_concise_body_needs_wrap(body) {
  * @param {boolean} is_right
  * @returns
  */
-function needs_parens(node, parent, is_right) {
+function operand_needs_wrap(node, parent, is_right) {
 	if (node.type === 'PrivateIdentifier') return false;
 
 	if (!is_right && (node.type === 'TSAsExpression' || node.type === 'TSSatisfiesExpression')) {
@@ -2428,6 +2345,21 @@ function needs_parens(node, parent, is_right) {
 	return OPERATOR_PRECEDENCE[operator] < OPERATOR_PRECEDENCE[parent.operator];
 }
 
+/**
+ * @param {Context} context
+ * @param {TSESTree.Node} node
+ * @param {boolean} wrap
+ */
+function maybe_wrap(context, node, wrap) {
+	if (wrap) {
+		context.write('(');
+		context.visit(node);
+		context.write(')');
+	} else {
+		context.visit(node);
+	}
+}
+
 /** @param {TSESTree.Node} node */
 function has_call_expression(node) {
 	while (node) {
@@ -2439,6 +2371,7 @@ function has_call_expression(node) {
 			return false;
 		}
 	}
+	return false;
 }
 
 /**

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -2409,7 +2409,7 @@ function needs_parens(node, parent, is_right) {
 		return (
 			(!is_right &&
 				(precedence === EXPRESSIONS_PRECEDENCE.UnaryExpression ||
-					node.type === 'AwaitExpression') &&
+					precedence === EXPRESSIONS_PRECEDENCE.AwaitExpression) &&
 				parent_precedence === EXPRESSIONS_PRECEDENCE.BinaryExpression &&
 				parent.operator === '**') ||
 			precedence < parent_precedence

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -46,10 +46,6 @@ export const EXPRESSIONS_PRECEDENCE = {
 	RestElement: 1
 };
 
-const UNARY_PRECEDENCE = EXPRESSIONS_PRECEDENCE.UnaryExpression;
-const BINARY_PRECEDENCE = EXPRESSIONS_PRECEDENCE.BinaryExpression;
-const LOGICAL_PRECEDENCE = EXPRESSIONS_PRECEDENCE.LogicalExpression;
-
 const OPERATOR_PRECEDENCE = {
 	'||': 2,
 	'&&': 3,
@@ -2412,14 +2408,18 @@ function needs_parens(node, parent, is_right) {
 		// Different node types
 		return (
 			(!is_right &&
-				(precedence === UNARY_PRECEDENCE || node.type === 'AwaitExpression') &&
-				parent_precedence === BINARY_PRECEDENCE &&
+				(precedence === EXPRESSIONS_PRECEDENCE.UnaryExpression ||
+					node.type === 'AwaitExpression') &&
+				parent_precedence === EXPRESSIONS_PRECEDENCE.BinaryExpression &&
 				parent.operator === '**') ||
 			precedence < parent_precedence
 		);
 	}
 
-	if (precedence !== LOGICAL_PRECEDENCE && precedence !== BINARY_PRECEDENCE) {
+	if (
+		precedence !== EXPRESSIONS_PRECEDENCE.LogicalExpression &&
+		precedence !== EXPRESSIONS_PRECEDENCE.BinaryExpression
+	) {
 		// Not a `LogicalExpression` or `BinaryExpression`
 		return false;
 	}

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -1437,10 +1437,11 @@ export default (options = {}) => {
 		LogicalExpression: shared['BinaryExpression|LogicalExpression'],
 
 		MemberExpression(node, context) {
-			if (
+			const needs_parens =
 				node.object.type === 'ChainExpression' ||
-				EXPRESSIONS_PRECEDENCE[node.object.type] < EXPRESSIONS_PRECEDENCE.MemberExpression
-			) {
+				EXPRESSIONS_PRECEDENCE[node.object.type] < EXPRESSIONS_PRECEDENCE.MemberExpression;
+
+			if (needs_parens) {
 				context.write('(');
 				context.visit(node.object);
 				context.write(')');
@@ -2404,46 +2405,28 @@ function needs_parens(node, parent, is_right) {
 	const precedence = EXPRESSIONS_PRECEDENCE[node.type];
 	const parent_precedence = EXPRESSIONS_PRECEDENCE[parent.type];
 
-	if (precedence !== parent_precedence) {
-		// Different node types
-		return (
-			(!is_right &&
-				(precedence === EXPRESSIONS_PRECEDENCE.UnaryExpression ||
-					precedence === EXPRESSIONS_PRECEDENCE.AwaitExpression) &&
-				parent_precedence === EXPRESSIONS_PRECEDENCE.BinaryExpression &&
-				parent.operator === '**') ||
-			precedence < parent_precedence
-		);
-	}
+	// `**` can't take a unary/await left operand: `-2 ** 2`, `await x ** 2` are syntax errors
+	const unary_base_of_pow =
+		!is_right &&
+		parent.operator === '**' &&
+		(node.type === 'UnaryExpression' || node.type === 'AwaitExpression');
 
-	if (
-		precedence !== EXPRESSIONS_PRECEDENCE.LogicalExpression &&
-		precedence !== EXPRESSIONS_PRECEDENCE.BinaryExpression
-	) {
-		// Not a `LogicalExpression` or `BinaryExpression`
-		return false;
-	}
+	if (unary_base_of_pow) return true;
+	if (precedence !== parent_precedence) return precedence < parent_precedence;
 
-	if (
-		/** @type {TSESTree.BinaryExpression} */ (node).operator === '**' &&
-		parent.operator === '**'
-	) {
-		// Exponentiation operator has right-to-left associativity
+	const operator = /** @type {TSESTree.BinaryExpression} */ (node).operator;
+
+	if (operator === '**' && parent.operator === '**') {
+		// exponentiation is right-associative
 		return !is_right;
 	}
 
 	if (is_right) {
-		// Parenthesis are used if both operators have the same precedence
-		return (
-			OPERATOR_PRECEDENCE[/** @type {TSESTree.BinaryExpression} */ (node).operator] <=
-			OPERATOR_PRECEDENCE[parent.operator]
-		);
+		// parentheses are needed when both operators have the same precedence
+		return OPERATOR_PRECEDENCE[operator] <= OPERATOR_PRECEDENCE[parent.operator];
 	}
 
-	return (
-		OPERATOR_PRECEDENCE[/** @type {TSESTree.BinaryExpression} */ (node).operator] <
-		OPERATOR_PRECEDENCE[parent.operator]
-	);
+	return OPERATOR_PRECEDENCE[operator] < OPERATOR_PRECEDENCE[parent.operator];
 }
 
 /** @param {TSESTree.Node} node */

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -511,11 +511,23 @@ export default (options = {}) => {
 			// 	// Avoids confusion in `for` loops initializers
 			// 	chunks.write('(');
 			// }
-			maybe_wrap(context, node.left, operand_needs_wrap(node.left, node, false));
+			if (needs_parens(node.left, node, false)) {
+				context.write('(');
+				context.visit(node.left);
+				context.write(')');
+			} else {
+				context.visit(node.left);
+			}
 
 			context.write(` ${node.operator} `);
 
-			maybe_wrap(context, node.right, operand_needs_wrap(node.right, node, true));
+			if (needs_parens(node.right, node, true)) {
+				context.write('(');
+				context.visit(node.right);
+				context.write(')');
+			} else {
+				context.visit(node.right);
+			}
 		},
 
 		/**
@@ -563,12 +575,18 @@ export default (options = {}) => {
 				write_keyword(context, node, 'new', ' ');
 			}
 
-			const wrap =
+			const needs_parens =
 				node.callee.type === 'ChainExpression' ||
 				EXPRESSIONS_PRECEDENCE[node.callee.type] < EXPRESSIONS_PRECEDENCE.CallExpression ||
 				(node.type === 'NewExpression' && has_call_expression(node.callee));
 
-			maybe_wrap(context, node.callee, wrap);
+			if (needs_parens) {
+				context.write('(');
+				context.visit(node.callee);
+				context.write(')');
+			} else {
+				context.visit(node.callee);
+			}
 
 			if (/** @type {TSESTree.CallExpression} */ (node).optional) {
 				context.write('?.');
@@ -909,6 +927,7 @@ export default (options = {}) => {
 			}
 
 			context.write('(');
+
 			sequence(
 				context,
 				// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
@@ -935,6 +954,7 @@ export default (options = {}) => {
 			if (node.typeParameters) context.visit(node.typeParameters);
 
 			context.write('(');
+
 			sequence(
 				context,
 				// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
@@ -945,9 +965,8 @@ export default (options = {}) => {
 					null,
 				false
 			);
-			context.write(')');
 
-			context.write(' => ');
+			context.write(') => ');
 
 			// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
 			context.visit(node.typeAnnotation?.typeAnnotation ?? node.returnType?.typeAnnotation);
@@ -993,7 +1012,13 @@ export default (options = {}) => {
 
 			context.write(' => ');
 
-			maybe_wrap(context, node.body, arrow_concise_body_needs_wrap(node.body));
+			if (arrow_concise_body_needs_wrap(node.body)) {
+				context.write('(');
+				context.visit(node.body);
+				context.write(')');
+			} else {
+				context.visit(node.body);
+			}
 		},
 
 		AssignmentExpression(node, context) {
@@ -1052,10 +1077,13 @@ export default (options = {}) => {
 		ClassExpression: shared['ClassDeclaration|ClassExpression'],
 
 		ConditionalExpression(node, context) {
-			const wrap =
-				EXPRESSIONS_PRECEDENCE[node.test.type] <= EXPRESSIONS_PRECEDENCE.ConditionalExpression;
-
-			maybe_wrap(context, node.test, wrap);
+			if (EXPRESSIONS_PRECEDENCE[node.test.type] > EXPRESSIONS_PRECEDENCE.ConditionalExpression) {
+				context.visit(node.test);
+			} else {
+				context.write('(');
+				context.visit(node.test);
+				context.write(')');
+			}
 
 			const consequent = context.new();
 			const alternate = context.new();
@@ -1213,14 +1241,20 @@ export default (options = {}) => {
 		},
 
 		ExpressionStatement(node, context) {
-			// wrap when a leading `{`/`function` would otherwise be parsed as a block/declaration
-			const wrap =
+			if (
 				node.expression.type === 'ObjectExpression' ||
 				(node.expression.type === 'AssignmentExpression' &&
 					node.expression.left.type === 'ObjectPattern') ||
-				node.expression.type === 'FunctionExpression';
+				node.expression.type === 'FunctionExpression'
+			) {
+				// is an AssignmentExpression to an ObjectPattern
+				context.write('(');
+				context.visit(node.expression);
+				context.write(');');
+				return;
+			}
 
-			maybe_wrap(context, node.expression, wrap);
+			context.visit(node.expression);
 			context.write(';');
 		},
 
@@ -1403,11 +1437,17 @@ export default (options = {}) => {
 		LogicalExpression: shared['BinaryExpression|LogicalExpression'],
 
 		MemberExpression(node, context) {
-			const wrap =
+			const needs_parens =
 				node.object.type === 'ChainExpression' ||
 				EXPRESSIONS_PRECEDENCE[node.object.type] < EXPRESSIONS_PRECEDENCE.MemberExpression;
 
-			maybe_wrap(context, node.object, wrap);
+			if (needs_parens) {
+				context.write('(');
+				context.visit(node.object);
+				context.write(')');
+			} else {
+				context.visit(node.object);
+			}
 
 			if (node.computed) {
 				if (node.optional) {
@@ -1448,7 +1488,9 @@ export default (options = {}) => {
 
 		// @ts-expect-error this isn't a real node type, but Acorn produces it
 		ParenthesizedExpression(node, context) {
-			maybe_wrap(context, node.expression, true);
+			context.write('(');
+			context.visit(node.expression);
+			context.write(')');
 		},
 
 		PrivateIdentifier(node, context) {
@@ -1597,7 +1639,13 @@ export default (options = {}) => {
 		},
 
 		TaggedTemplateExpression(node, context) {
-			maybe_wrap(context, node.tag, node.tag.type === 'ChainExpression');
+			if (node.tag.type === 'ChainExpression') {
+				context.write('(');
+				context.visit(node.tag);
+				context.write(')');
+			} else {
+				context.visit(node.tag);
+			}
 			context.visit(node.quasi);
 		},
 
@@ -1680,10 +1728,13 @@ export default (options = {}) => {
 				context.write(' ');
 			}
 
-			const wrap =
-				EXPRESSIONS_PRECEDENCE[node.argument.type] < EXPRESSIONS_PRECEDENCE.UnaryExpression;
-
-			maybe_wrap(context, node.argument, wrap);
+			if (EXPRESSIONS_PRECEDENCE[node.argument.type] < EXPRESSIONS_PRECEDENCE.UnaryExpression) {
+				context.write('(');
+				context.visit(node.argument);
+				context.write(')');
+			} else {
+				context.visit(node.argument);
+			}
 		},
 
 		UpdateExpression(node, context) {
@@ -1919,10 +1970,13 @@ export default (options = {}) => {
 			context.write('<');
 			context.visit(node.typeAnnotation);
 			context.write('>');
-			const wrap =
-				EXPRESSIONS_PRECEDENCE[node.expression.type] < EXPRESSIONS_PRECEDENCE.TSTypeAssertion;
-
-			maybe_wrap(context, node.expression, wrap);
+			if (EXPRESSIONS_PRECEDENCE[node.expression.type] < EXPRESSIONS_PRECEDENCE.TSTypeAssertion) {
+				context.write('(');
+				context.visit(node.expression);
+				context.write(')');
+			} else {
+				context.visit(node.expression);
+			}
 		},
 
 		TSTypeParameterInstantiation(node, context) {
@@ -2041,6 +2095,7 @@ export default (options = {}) => {
 			context.visit(node.key);
 
 			context.write('(');
+
 			sequence(
 				context,
 				// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
@@ -2154,10 +2209,16 @@ export default (options = {}) => {
 
 		TSAsExpression(node, context) {
 			if (node.expression) {
-				const wrap =
+				const needs_parens =
 					EXPRESSIONS_PRECEDENCE[node.expression.type] < EXPRESSIONS_PRECEDENCE.TSAsExpression;
 
-				maybe_wrap(context, node.expression, wrap);
+				if (needs_parens) {
+					context.write('(');
+					context.visit(node.expression);
+					context.write(')');
+				} else {
+					context.visit(node.expression);
+				}
 			}
 			context.write(' as ');
 			context.visit(node.typeAnnotation);
@@ -2203,10 +2264,15 @@ export default (options = {}) => {
 
 		TSNonNullExpression(node, context) {
 			// operator expressions can't take a postfix `!` directly: `(0 as number)!`, `(await x)!`
-			const wrap =
-				EXPRESSIONS_PRECEDENCE[node.expression.type] < EXPRESSIONS_PRECEDENCE.TSNonNullExpression;
-
-			maybe_wrap(context, node.expression, wrap);
+			if (
+				EXPRESSIONS_PRECEDENCE[node.expression.type] < EXPRESSIONS_PRECEDENCE.TSNonNullExpression
+			) {
+				context.write('(');
+				context.visit(node.expression);
+				context.write(')');
+			} else {
+				context.visit(node.expression);
+			}
 			context.write('!');
 		},
 
@@ -2240,16 +2306,24 @@ export default (options = {}) => {
 
 		//@ts-expect-error I don't know why, but this is relied upon in the tests, but doesn't exist in the TSESTree types
 		TSParenthesizedType(node, context) {
-			maybe_wrap(context, node.typeAnnotation, true);
+			context.write('(');
+			context.visit(node.typeAnnotation);
+			context.write(')');
 		},
 
 		TSSatisfiesExpression(node, context) {
 			if (node.expression) {
-				const wrap =
+				const needs_parens =
 					EXPRESSIONS_PRECEDENCE[node.expression.type] <
 					EXPRESSIONS_PRECEDENCE.TSSatisfiesExpression;
 
-				maybe_wrap(context, node.expression, wrap);
+				if (needs_parens) {
+					context.write('(');
+					context.visit(node.expression);
+					context.write(')');
+				} else {
+					context.visit(node.expression);
+				}
 			}
 			context.write(' satisfies ');
 			context.visit(node.typeAnnotation);
@@ -2309,7 +2383,7 @@ function arrow_concise_body_needs_wrap(body) {
  * @param {boolean} is_right
  * @returns
  */
-function operand_needs_wrap(node, parent, is_right) {
+function needs_parens(node, parent, is_right) {
 	if (node.type === 'PrivateIdentifier') return false;
 
 	if (!is_right && (node.type === 'TSAsExpression' || node.type === 'TSSatisfiesExpression')) {
@@ -2354,21 +2428,6 @@ function operand_needs_wrap(node, parent, is_right) {
 	return OPERATOR_PRECEDENCE[operator] < OPERATOR_PRECEDENCE[parent.operator];
 }
 
-/**
- * @param {Context} context
- * @param {TSESTree.Node} node
- * @param {boolean} wrap
- */
-function maybe_wrap(context, node, wrap) {
-	if (wrap) {
-		context.write('(');
-		context.visit(node);
-		context.write(')');
-	} else {
-		context.visit(node);
-	}
-}
-
 /** @param {TSESTree.Node} node */
 function has_call_expression(node) {
 	while (node) {
@@ -2380,7 +2439,6 @@ function has_call_expression(node) {
 			return false;
 		}
 	}
-	return false;
 }
 
 /**

--- a/test/paren-correctness.test.js
+++ b/test/paren-correctness.test.js
@@ -1,0 +1,86 @@
+// @ts-check
+
+import { expect, test } from 'vitest';
+import { acornParse } from './common.js';
+import { print } from '../src/index.js';
+import ts from '../src/languages/ts/index.js';
+
+/** @param {string} input */
+function printed(input) {
+	const { ast } = acornParse(input);
+	return print(ast, ts()).code;
+}
+
+// nested same-sign unary operators must not be glued into `--`/`++`, which would
+// change the meaning (`-(-a)` -> `--a` is the decrement operator) or be invalid
+
+test('keeps a space between nested unary minus operators', () => {
+	const code = printed('-(-a);');
+	expect(code).toBe('- -a;');
+	expect(() => acornParse(code)).not.toThrow();
+});
+
+test('keeps a space between nested unary plus operators', () => {
+	const code = printed('+(+a);');
+	expect(code).toBe('+ +a;');
+	expect(() => acornParse(code)).not.toThrow();
+});
+
+test('keeps a space between a unary minus and a prefix decrement', () => {
+	const code = printed('-(--a);');
+	expect(code).toBe('- --a;');
+	expect(() => acornParse(code)).not.toThrow();
+});
+
+// a parenthesized optional chain is a separate chain — dropping the parentheses
+// changes its short-circuiting behaviour or produces invalid output
+
+test('keeps parentheses around an optional chain that is called', () => {
+	const code = printed('(a?.b)();');
+	expect(code).toBe('(a?.b)();');
+	expect(() => acornParse(code)).not.toThrow();
+});
+
+test('keeps parentheses around an optional chain that is a member object', () => {
+	const code = printed('(a?.b).c;');
+	expect(code).toBe('(a?.b).c;');
+	expect(() => acornParse(code)).not.toThrow();
+});
+
+test('keeps parentheses around an optional chain in a `new` callee', () => {
+	const code = printed('new (a?.b)();');
+	expect(code).toBe('new (a?.b)();');
+	expect(() => acornParse(code)).not.toThrow();
+});
+
+test('keeps parentheses around an optional chain under `delete`', () => {
+	const code = printed('delete (a?.b).c;');
+	expect(code).toBe('delete (a?.b).c;');
+	expect(() => acornParse(code)).not.toThrow();
+});
+
+test('keeps parentheses around an optional chain used as a template tag', () => {
+	const code = printed('(a?.b)`x`;');
+	expect(code).toBe('(a?.b)`x`;');
+	expect(() => acornParse(code)).not.toThrow();
+});
+
+test('keeps parentheses around an optional call that is itself called', () => {
+	const code = printed('(a?.())();');
+	expect(code).toBe('(a?.())();');
+	expect(() => acornParse(code)).not.toThrow();
+});
+
+test('does not parenthesize genuine optional chains', () => {
+	for (const input of ['a?.b.c;', 'a?.b().c;', 'a?.b?.c;']) {
+		expect(printed(input)).toBe(input);
+	}
+});
+
+// `await` is not a valid left operand of `**` and must stay parenthesized
+
+test('keeps parentheses around an `await` operand of `**`', () => {
+	const code = printed('async () => (await a) ** b;');
+	expect(code).toBe('async () => (await a) ** b;');
+	expect(() => acornParse(code)).not.toThrow();
+});

--- a/test/paren-correctness.test.js
+++ b/test/paren-correctness.test.js
@@ -46,3 +46,19 @@ test('keeps parentheses around an `await` operand of `**`', () => {
 	expect(code).toBe('async () => (await a) ** b;');
 	expect(() => acornParse(code)).not.toThrow();
 });
+
+// `?:` is right-associative, so a conditional in the test position must keep its
+// parentheses, otherwise `(a ? b : c) ? d : e` re-associates to `a ? b : (c ? d : e)`
+test.each([
+	'(a ? b : c) ? d : e;',
+	'(a ? b : c) ? d : e ? f : g;'
+])('keeps parentheses around a conditional test %j', (input) => {
+	const code = printed(input);
+	expect(code).toBe(input);
+	expect(() => acornParse(code)).not.toThrow();
+});
+
+// a conditional in the consequent/alternate position does NOT need parentheses
+test('leaves a nested conditional in the alternate untouched', () => {
+	expect(printed('a ? b : c ? d : e;')).toBe('a ? b : c ? d : e;');
+});

--- a/test/paren-correctness.test.js
+++ b/test/paren-correctness.test.js
@@ -11,7 +11,8 @@ function printed(input) {
 }
 
 // nested same-sign unary operators must not be glued into `--`/`++`, which would
-// change the meaning (`-(-a)` -> `--a` is the decrement operator) or be invalid
+// change the meaning (`-(-a)` -> `--a` is the decrement operator) or be invalid.
+// these transform the input, so we also assert the output re-parses cleanly
 test.each([
 	['-(-a);', '- -a;'],
 	['+(+a);', '+ +a;'],
@@ -22,43 +23,28 @@ test.each([
 	expect(() => acornParse(code)).not.toThrow();
 });
 
-// a parenthesized optional chain is a separate chain — dropping the parentheses
-// changes its short-circuiting behaviour or produces invalid output
+// each of these must round-trip unchanged: dropping or adding parentheses here
+// would change meaning or produce invalid code
 test.each([
+	// a parenthesized optional chain is a separate chain
 	'(a?.b)();',
 	'(a?.b).c;',
 	'new (a?.b)();',
 	'delete (a?.b).c;',
 	'(a?.b)`x`;',
-	'(a?.())();'
-])('keeps parentheses around %j', (input) => {
-	expect(printed(input)).toBe(input);
-});
-
-// genuine optional chains must not gain parentheses
-test.each(['a?.b.c;', 'a?.b().c;', 'a?.b?.c;'])('leaves %j untouched', (input) => {
-	expect(printed(input)).toBe(input);
-});
-
-// `await` is not a valid left operand of `**` and must stay parenthesized
-test('keeps parentheses around an `await` operand of `**`', () => {
-	const code = printed('async () => (await a) ** b;');
-	expect(code).toBe('async () => (await a) ** b;');
-	expect(() => acornParse(code)).not.toThrow();
-});
-
-// `?:` is right-associative, so a conditional in the test position must keep its
-// parentheses, otherwise `(a ? b : c) ? d : e` re-associates to `a ? b : (c ? d : e)`
-test.each([
+	'(a?.())();',
+	// `await` is not a valid left operand of `**`
+	'async () => (await a) ** b;',
+	// `?:` is right-associative, so a conditional in the test position keeps its
+	// parens, else `(a ? b : c) ? d : e` re-associates to `a ? b : (c ? d : e)`
 	'(a ? b : c) ? d : e;',
-	'(a ? b : c) ? d : e ? f : g;'
-])('keeps parentheses around a conditional test %j', (input) => {
-	const code = printed(input);
-	expect(code).toBe(input);
-	expect(() => acornParse(code)).not.toThrow();
-});
-
-// a conditional in the consequent/alternate position does NOT need parentheses
-test('leaves a nested conditional in the alternate untouched', () => {
-	expect(printed('a ? b : c ? d : e;')).toBe('a ? b : c ? d : e;');
+	'(a ? b : c) ? d : e ? f : g;',
+	// genuine optional chains must not gain parentheses
+	'a?.b.c;',
+	'a?.b().c;',
+	'a?.b?.c;',
+	// a conditional in the alternate position needs no parentheses
+	'a ? b : c ? d : e;'
+])('%j round-trips with correct parentheses', (input) => {
+	expect(printed(input)).toBe(input);
 });

--- a/test/paren-correctness.test.js
+++ b/test/paren-correctness.test.js
@@ -1,5 +1,4 @@
 // @ts-check
-
 import { expect, test } from 'vitest';
 import { acornParse } from './common.js';
 import { print } from '../src/index.js';
@@ -13,72 +12,35 @@ function printed(input) {
 
 // nested same-sign unary operators must not be glued into `--`/`++`, which would
 // change the meaning (`-(-a)` -> `--a` is the decrement operator) or be invalid
-
-test('keeps a space between nested unary minus operators', () => {
-	const code = printed('-(-a);');
-	expect(code).toBe('- -a;');
-	expect(() => acornParse(code)).not.toThrow();
-});
-
-test('keeps a space between nested unary plus operators', () => {
-	const code = printed('+(+a);');
-	expect(code).toBe('+ +a;');
-	expect(() => acornParse(code)).not.toThrow();
-});
-
-test('keeps a space between a unary minus and a prefix decrement', () => {
-	const code = printed('-(--a);');
-	expect(code).toBe('- --a;');
+test.each([
+	['-(-a);', '- -a;'],
+	['+(+a);', '+ +a;'],
+	['-(--a);', '- --a;']
+])('prints %j as %j without gluing operators', (input, expected) => {
+	const code = printed(input);
+	expect(code).toBe(expected);
 	expect(() => acornParse(code)).not.toThrow();
 });
 
 // a parenthesized optional chain is a separate chain — dropping the parentheses
 // changes its short-circuiting behaviour or produces invalid output
-
-test('keeps parentheses around an optional chain that is called', () => {
-	const code = printed('(a?.b)();');
-	expect(code).toBe('(a?.b)();');
-	expect(() => acornParse(code)).not.toThrow();
+test.each([
+	'(a?.b)();',
+	'(a?.b).c;',
+	'new (a?.b)();',
+	'delete (a?.b).c;',
+	'(a?.b)`x`;',
+	'(a?.())();'
+])('keeps parentheses around %j', (input) => {
+	expect(printed(input)).toBe(input);
 });
 
-test('keeps parentheses around an optional chain that is a member object', () => {
-	const code = printed('(a?.b).c;');
-	expect(code).toBe('(a?.b).c;');
-	expect(() => acornParse(code)).not.toThrow();
-});
-
-test('keeps parentheses around an optional chain in a `new` callee', () => {
-	const code = printed('new (a?.b)();');
-	expect(code).toBe('new (a?.b)();');
-	expect(() => acornParse(code)).not.toThrow();
-});
-
-test('keeps parentheses around an optional chain under `delete`', () => {
-	const code = printed('delete (a?.b).c;');
-	expect(code).toBe('delete (a?.b).c;');
-	expect(() => acornParse(code)).not.toThrow();
-});
-
-test('keeps parentheses around an optional chain used as a template tag', () => {
-	const code = printed('(a?.b)`x`;');
-	expect(code).toBe('(a?.b)`x`;');
-	expect(() => acornParse(code)).not.toThrow();
-});
-
-test('keeps parentheses around an optional call that is itself called', () => {
-	const code = printed('(a?.())();');
-	expect(code).toBe('(a?.())();');
-	expect(() => acornParse(code)).not.toThrow();
-});
-
-test('does not parenthesize genuine optional chains', () => {
-	for (const input of ['a?.b.c;', 'a?.b().c;', 'a?.b?.c;']) {
-		expect(printed(input)).toBe(input);
-	}
+// genuine optional chains must not gain parentheses
+test.each(['a?.b.c;', 'a?.b().c;', 'a?.b?.c;'])('leaves %j untouched', (input) => {
+	expect(printed(input)).toBe(input);
 });
 
 // `await` is not a valid left operand of `**` and must stay parenthesized
-
 test('keeps parentheses around an `await` operand of `**`', () => {
 	const code = printed('async () => (await a) ** b;');
 	expect(code).toBe('async () => (await a) ** b;');


### PR DESCRIPTION
After https://github.com/sveltejs/esrap/issues/131 i did an audit and found some more bugs in esrap that could be very difficult to find in code running in production. I also saw @Conduitry's message on https://github.com/sveltejs/esrap/pull/132 saying _"I do think it would be valuable to try to find a way to avoid these sorts of issues - perhaps by more constants, rather than magic numbers that can get out of sync."_, so i did that as well.

List of bugs that this PR fixes:
- `-(-a)` was printed as `--a` (the decrement operator) — wrong meaning
- `+(+a)` was printed as `++a` (the increment operator) — wrong meaning
- `-(--a)` was printed as `---a` — invalid syntax
- `(a?.b)()` was printed as `a?.b()` — changes short-circuit behavior (throws vs. returns undefined when a is nullish)
- `(a?.b).c` was printed as `a?.b.c` — same short-circuit behavior change
- `delete (a?.b).c` was printed as `delete a?.b.c` — same short-circuit behavior change
- `new (a?.b)()` was printed as `new a?.b()` — invalid syntax
- `` (a?.b)`x` `` was printed as `` a?.b`x` `` — invalid syntax
- `(a?.())()` was printed as `a?.()()` — changes short-circuit behavior
- `(await a) ** b` was printed as `await a ** b` — invalid syntax
