### PR TITLE
fix: preserve `?` on optional identifiers

### DIFF
--- a/.changeset/optional-identifier.md
+++ b/.changeset/optional-identifier.md
@@ -1,0 +1,5 @@
+---
+'esrap': patch
+---
+
+fix: preserve `?` on optional identifiers (e.g. optional parameters)

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -1289,6 +1289,7 @@ export default (options = {}) => {
 			let name = node.name;
 			context.write(name, node);
 
+			if (node.optional) context.write('?');
 			if (node.typeAnnotation) context.visit(node.typeAnnotation);
 		},
 

--- a/test/samples/ts-optional-parameter/expected.ts
+++ b/test/samples/ts-optional-parameter/expected.ts
@@ -1,0 +1,1 @@
+export const atproto = (o?: { A?: string }) => {};

--- a/test/samples/ts-optional-parameter/expected.ts.map
+++ b/test/samples/ts-optional-parameter/expected.ts.map
@@ -5,7 +5,7 @@
     "input.js"
   ],
   "sourcesContent": [
-    "export const atproto = (o?: {\n\tA?: string;\n}) => {};\n"
+    "export const atproto = (o?: { A?: string }) => {};\n"
   ],
-  "mappings": "AAAA,MAAM,CAAC,MAAM,AAAA,OAAO,IAAI,CAEvB,KADA,CAAC,GAAG,MAAM,OACL,CAAC,AAAA,CAAC"
+  "mappings": "AAAA,MAAM,CAAC,MAAM,AAAA,OAAO,IAAI,CAAkB,KAAZ,CAAC,GAAG,MAAM,OAAO,CAAC,AAAA,CAAC"
 }

--- a/test/samples/ts-optional-parameter/expected.ts.map
+++ b/test/samples/ts-optional-parameter/expected.ts.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": [
+    "input.js"
+  ],
+  "sourcesContent": [
+    "export const atproto = (o?: {\n\tA?: string;\n}) => {};\n"
+  ],
+  "mappings": "AAAA,MAAM,CAAC,MAAM,AAAA,OAAO,IAAI,CAEvB,KADA,CAAC,GAAG,MAAM,OACL,CAAC,AAAA,CAAC"
+}

--- a/test/samples/ts-optional-parameter/input.ts
+++ b/test/samples/ts-optional-parameter/input.ts
@@ -1,3 +1,1 @@
-export const atproto = (o?: {
-	A?: string;
-}) => {};
+export const atproto = (o?: { A?: string }) => {};

--- a/test/samples/ts-optional-parameter/input.ts
+++ b/test/samples/ts-optional-parameter/input.ts
@@ -1,0 +1,3 @@
+export const atproto = (o?: {
+	A?: string;
+}) => {};


### PR DESCRIPTION
The TS `Identifier` printer drops the `optional` flag, so an optional parameter `o?: {...}` round-trips to `o: {...}` (the `?` is silently lost). Inner `TSPropertySignature` optionals were fine; only the `Identifier` path was missing the check.

```js
Identifier(node, context) {
	let name = node.name;
	context.write(name, node);
	if (node.optional) context.write('?'); // added
	if (node.typeAnnotation) context.visit(node.typeAnnotation);
},
```

Found while migrating Svelte code via `sveltejs/cli` (PR sveltejs/cli#1058), where reserializing untouched functions stripped optional params.

Includes a test and a changeset.