### PR TITLE
test: lock in faithful printing of optional identifiers

### DIFF
--- a/test/optional-parameter.test.js
+++ b/test/optional-parameter.test.js
@@ -1,0 +1,20 @@
+// @ts-check
+import { expect, test } from 'vitest';
+import { acornParse } from './common.js';
+import { print } from '../src/index.js';
+import ts from '../src/languages/ts/index.js';
+
+/** @param {string} input */
+function printed(input) {
+	const { ast } = acornParse(input);
+	return print(ast, ts()).code;
+}
+
+// `?` on optional identifiers must be preserved (see #139)
+test.each([
+	'const f = (o?: { A?: string }) => {};',
+	'function a(disabled?) {}',
+	'function openEventForm(startDate?, endDate?, allDay = false) {}'
+])('preserves `?` on optional identifiers: %j', (input) => {
+	expect(printed(input)).toBe(input);
+});


### PR DESCRIPTION
close: https://github.com/sveltejs/esrap/issues/142

Add regression tests ensuring esrap preserves the `?` on optional identifiers (introduced in #139), covering optional parameters with and without a type annotation. Documents that #142 was a Svelte-side issue (stale TS-only `optional` flag after stripping types), fixed in Svelte 5.56.4, not an esrap bug.

Since `function a(disabled?)` is valid in TypeScript, I believe the current behavior of esrap is correct.
https://www.typescriptlang.org/play/?noImplicitAny=false#code/GYVwdgxgLglg9mABAQwBQBMYGdkCMA2ApugPwCUiA3gFCJ2IQJZxEB0+cA5htnkemWoBfIA