### PR TITLE
fix: print class type parameters

### DIFF
--- a/.changeset/class-type-parameters.md
+++ b/.changeset/class-type-parameters.md
@@ -1,0 +1,5 @@
+---
+'esrap': patch
+---
+
+fix: print class type parameters (`class Foo<T>`)

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -653,6 +653,13 @@ export default (options = {}) => {
 
 			if (node.id) {
 				context.visit(node.id);
+			}
+
+			if (node.typeParameters) {
+				context.visit(node.typeParameters);
+			}
+
+			if (node.id || node.typeParameters) {
 				context.write(' ');
 			}
 

--- a/test/samples/ts-class-type-parameters/expected.ts
+++ b/test/samples/ts-class-type-parameters/expected.ts
@@ -1,0 +1,2 @@
+class Foo<T> {}
+class Baz<T> extends Bar<T> {}

--- a/test/samples/ts-class-type-parameters/expected.ts.map
+++ b/test/samples/ts-class-type-parameters/expected.ts.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": [
+    "input.js"
+  ],
+  "sourcesContent": [
+    "class Foo<T> {}\nclass Baz<T> extends Bar<T> {}\n"
+  ],
+  "mappings": "AAAA,MAAM,AAAA,GAAG,CAAC,CAAC,EAAE,CAAC,AAAA,CAAC;AACf,MAAM,AAAA,GAAG,CAAC,CAAC,UAAU,GAAG,CAAC,CAAC,EAAE,CAAC,AAAA,CAAC"
+}

--- a/test/samples/ts-class-type-parameters/input.ts
+++ b/test/samples/ts-class-type-parameters/input.ts
@@ -1,0 +1,2 @@
+class Foo<T> {}
+class Baz<T> extends Bar<T> {}


### PR DESCRIPTION
The TS `ClassDeclaration`/`ClassExpression` printer never visits `node.typeParameters`, so a generic class `class Foo<T> {}` round-trips to `class Foo {}` (the `<T>` is silently lost). `superTypeParameters` on `extends` were handled, but the class's own type parameters were missing.

```js
if (node.id) {
	context.visit(node.id);
}

if (node.typeParameters) {
	context.visit(node.typeParameters); // added
}

if (node.id || node.typeParameters) {
	context.write(' ');
}
```

Found while migrating Svelte code via `sveltejs/cli`, where reserializing untouched classes stripped generics.

Includes a test and a changeset.
