### PR TITLE
chore: shorten changesets

### DIFF
--- a/.changeset/paren-correctness.md
+++ b/.changeset/paren-correctness.md
@@ -3,7 +3,3 @@
 ---
 
 fix: preserve required parentheses in three more cases that changed meaning or produced invalid output
-
-- nested same-sign unary operators (`-(-a)` was printed as `--a`, the decrement operator; `-(--a)` as invalid `---a`)
-- parenthesized optional chains as a callee/object/tag/new (`(a?.b)()` was printed as `a?.b()`, silently changing short-circuit behavior; `new (a?.b)()` and ` (a?.b)` `` became invalid)
-- `await` as the left operand of `**` (`(await a) ** b` was printed as the SyntaxError `await a ** b`)

--- a/.changeset/preserve-ts-markers.md
+++ b/.changeset/preserve-ts-markers.md
@@ -3,5 +3,3 @@
 ---
 
 fix: preserve more TypeScript markers when printing
-
-Type parameters (classes & methods), class-field `?`/`!`/`readonly`/`declare`/`override`, type-parameter modifiers (`const`/`in`/`out`), and mapped-type modifiers were silently dropped.

--- a/.changeset/required-parens-positions.md
+++ b/.changeset/required-parens-positions.md
@@ -3,11 +3,3 @@
 ---
 
 fix: add parentheses required by specific grammar positions
-
-Previously esrap could drop parentheses that the position requires, producing invalid output or changing meaning:
-
-- the `extends` super-class (`class A extends (B || C) {}`)
-- a tagged-template tag (`` (x || y)`tpl` ``)
-- a decorator expression (`@(a ? b : c)`)
-- an angle-bracket type assertion as the left of `**` (`(<T>x) ** y`)
-- an expression statement that would otherwise start with `{`, `function`, or `class` (`({} + [])`, `(class {})`, `` (function(){})`x` ``)

--- a/.changeset/ts-token-emission.md
+++ b/.changeset/ts-token-emission.md
@@ -3,9 +3,3 @@
 ---
 
 fix: print valid TypeScript for `asserts` predicates, qualified namespaces, and computed signature keys
-
-These were previously emitted as invalid output:
-
-- `asserts` type predicates were printed in the wrong order (`asserts x is T` became `x asserts T`)
-- qualified namespace/module names were mangled (`namespace A.B.C` became `namespace Anamespace Bnamespace C`)
-- computed keys in method/property signatures lost their brackets (`interface I { [Symbol.iterator](): T }` became `Symbol.iterator(): T`)


### PR DESCRIPTION
I think they are overly long and make parsing the changelog a lot harder than necessary. The linked commit / pr will still reveal those details