### PR TITLE
feat: optional boundaryTokens source-map anchors for structural tokens

### DIFF
--- a/.changeset/anchored-structural-tokens.md
+++ b/.changeset/anchored-structural-tokens.md
@@ -1,0 +1,5 @@
+---
+'esrap': minor
+---
+
+Add a `boundaryTokens` language option that anchors structural tokens (array/object brackets and braces, preserved parentheses, unary operators, and the closing tokens of calls and computed member access) with one-character source locations, so node-boundary positions resolve through the source map instead of being attributed to the previous token. Off by default; output is byte-identical either way

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -484,20 +484,50 @@ export default (options = {}) => {
 		}
 	}
 
+	const boundary_tokens = options.boundaryTokens === true;
+
+	/**
+	 * A one-character synthetic token node so structural tokens (`(`, `[`, `{`,
+	 * unary operators, …) written where a node's SOURCE span begins or ends get a
+	 * sourcemap anchor. Without it, everything up to the next mapped token is
+	 * attributed to the PREVIOUS token's source position — `write(content, node)`
+	 * only maps tokens written with a node, and these boundary characters belong
+	 * to no written token. Opt-in (`boundaryTokens`): denser maps, byte-identical
+	 * output.
+	 * @param {{ line: number, column: number } | undefined} pos
+	 * @param {number} [length]
+	 */
+	function token_at(pos, length = 1) {
+		if (!boundary_tokens) return undefined;
+		if (!pos) return undefined;
+		return /** @type {any} */ ({
+			loc: { start: pos, end: { line: pos.line, column: pos.column + length } }
+		});
+	}
+
+	/** @param {{ line: number, column: number } | undefined} pos */
+	function token_before(pos) {
+		if (!boundary_tokens) return undefined;
+		if (!pos || pos.column === 0) return undefined;
+		return /** @type {any} */ ({
+			loc: { start: { line: pos.line, column: pos.column - 1 }, end: pos }
+		});
+	}
+
 	const shared = {
 		/**
 		 * @param {TSESTree.ArrayExpression | TSESTree.ArrayPattern} node
 		 * @param {Context} context
 		 */
 		'ArrayExpression|ArrayPattern': (node, context) => {
-			context.write('[');
+			context.write('[', token_at(node.loc?.start));
 			sequence(
 				context,
 				/** @type {TSESTree.Node[]} */ (node.elements),
 				node.loc?.end ?? null,
 				false
 			);
-			context.write(']');
+			context.write(']', token_before(node.loc?.end));
 		},
 
 		/**
@@ -631,7 +661,7 @@ export default (options = {}) => {
 				join.write(' ');
 			}
 
-			context.write(')');
+			context.write(')', token_before(node.loc?.end));
 		},
 
 		/**
@@ -804,9 +834,9 @@ export default (options = {}) => {
 
 			if (node.value.generator) context.write('*');
 
-			if (node.computed) context.write('[');
+			if (node.computed) context.write('[', token_before(node.key.loc?.start));
 			context.visit(node.key);
-			if (node.computed) context.write(']');
+			if (node.computed) context.write(']', token_at(node.key.loc?.end));
 
 			// optional method (`m?()`)
 			if (node.optional) context.write('?');
@@ -879,9 +909,9 @@ export default (options = {}) => {
 			}
 
 			if (node.computed) {
-				context.write('[');
+				context.write('[', token_before(node.key.loc?.start));
 				context.visit(node.key);
-				context.write(']');
+				context.write(']', token_at(node.key.loc?.end));
 			} else {
 				context.visit(node.key);
 			}
@@ -1446,7 +1476,7 @@ export default (options = {}) => {
 				}
 				context.write('[');
 				context.visit(node.property);
-				context.write(']');
+				context.write(']', token_before(node.loc?.end));
 			} else {
 				context.write(node.optional ? '?.' : '.');
 				context.visit(node.property);
@@ -1464,22 +1494,28 @@ export default (options = {}) => {
 		NewExpression: shared['CallExpression|NewExpression'],
 
 		ObjectExpression(node, context) {
-			context.write('{');
+			context.write('{', token_at(node.loc?.start));
 			sequence(context, node.properties, node.loc?.end ?? null, true);
-			context.write('}');
+			context.write('}', token_before(node.loc?.end));
 		},
 
 		ObjectPattern(node, context) {
-			context.write('{');
+			context.write('{', token_at(node.loc?.start));
 			sequence(context, node.properties, node.loc?.end ?? null, true);
-			context.write('}');
+			context.write('}', token_before(node.loc?.end));
 
 			if (node.typeAnnotation) context.visit(node.typeAnnotation);
 		},
 
 		// @ts-expect-error this isn't a real node type, but Acorn produces it
 		ParenthesizedExpression(node, context) {
-			maybe_wrap(context, node.expression, true);
+			if (node.loc) {
+				context.write('(', token_at(node.loc.start));
+				context.visit(node.expression);
+				context.write(')', token_before(node.loc.end));
+			} else {
+				maybe_wrap(context, node.expression, true);
+			}
 		},
 
 		PrivateIdentifier(node, context) {
@@ -1513,9 +1549,9 @@ export default (options = {}) => {
 				if (node.kind !== 'init') kw(node.kind + ' ');
 				if (node.value.async) kw('async ');
 				if (node.value.generator) context.write('*');
-				if (node.computed) context.write('[');
+				if (node.computed) context.write('[', token_before(node.key.loc?.start));
 				context.visit(node.key);
-				if (node.computed) context.write(']');
+				if (node.computed) context.write(']', token_at(node.key.loc?.end));
 				context.write('(');
 				sequence(
 					context,
@@ -1530,12 +1566,17 @@ export default (options = {}) => {
 				context.write(' ');
 				context.visit(node.value.body);
 			} else {
-				if (node.computed) context.write('[');
+				if (node.computed) context.write('[', token_before(node.key.loc?.start));
 				if (node.kind === 'get' || node.kind === 'set') {
 					write_keyword(context, node, node.kind, ' ');
 				}
 				context.visit(node.key);
-				context.write(node.computed ? ']: ' : ': ');
+				if (node.computed) {
+					context.write(']', token_at(node.key.loc?.end));
+					context.write(': ');
+				} else {
+					context.write(': ');
+				}
 				context.visit(node.value);
 			}
 		},
@@ -1702,7 +1743,7 @@ export default (options = {}) => {
 		},
 
 		UnaryExpression(node, context) {
-			context.write(node.operator);
+			context.write(node.operator, token_at(node.loc?.start, node.operator.length));
 
 			if (node.operator.length > 1) {
 				context.write(' ');
@@ -1886,9 +1927,9 @@ export default (options = {}) => {
 		},
 
 		TSPropertySignature(node, context) {
-			if (node.computed) context.write('[');
+			if (node.computed) context.write('[', token_before(node.key.loc?.start));
 			context.visit(node.key);
-			if (node.computed) context.write(']');
+			if (node.computed) context.write(']', token_at(node.key.loc?.end));
 			if (node.optional) context.write('?');
 			if (node.typeAnnotation) context.visit(node.typeAnnotation);
 		},
@@ -2094,9 +2135,9 @@ export default (options = {}) => {
 		},
 
 		TSMethodSignature(node, context) {
-			if (node.computed) context.write('[');
+			if (node.computed) context.write('[', token_before(node.key.loc?.start));
 			context.visit(node.key);
-			if (node.computed) context.write(']');
+			if (node.computed) context.write(']', token_at(node.key.loc?.end));
 
 			context.write('(');
 			sequence(

--- a/src/languages/types.d.ts
+++ b/src/languages/types.d.ts
@@ -2,6 +2,14 @@ import type { BaseNode } from '../types';
 
 export type TSOptions = {
 	quotes?: 'double' | 'single';
+	/**
+	 * Anchor structural tokens (array/object brackets and braces, preserved
+	 * parentheses, unary operators, and the closing tokens of calls and
+	 * computed member access) with one-character source locations, so
+	 * node-boundary positions always resolve through the source map instead of
+	 * being attributed to the previous token. Denser maps; identical output.
+	 */
+	boundaryTokens?: boolean;
 	comments?: Comment[];
 	getLeadingComments?: (node: BaseNode) => BaseComment[] | undefined;
 	getTrailingComments?: (node: BaseNode) => BaseComment[] | undefined;

--- a/test/common.js
+++ b/test/common.js
@@ -10,7 +10,7 @@ export const acornTs = acorn.Parser.extend(tsPlugin());
 export const acornTsx = acorn.Parser.extend(tsPlugin({ jsx: true }));
 
 /** @param {string} input
- * @param {{ jsxMode?: boolean, sourceType?: 'module' | 'script' }} opts
+ * @param {{ jsxMode?: boolean, sourceType?: 'module' | 'script', preserveParens?: boolean }} opts
  */
 export function acornParse(input, opts = {}) {
 	const jsx = opts.jsxMode ?? false;
@@ -22,6 +22,7 @@ export function acornParse(input, opts = {}) {
 		ecmaVersion: 'latest',
 		sourceType,
 		locations: true,
+		preserveParens: opts.preserveParens ?? false,
 		onComment: (block, value, start, end, startLoc, endLoc) => {
 			if (block && /\n/.test(value)) {
 				let a = start;

--- a/test/sourcemap-keywords.test.js
+++ b/test/sourcemap-keywords.test.js
@@ -37,15 +37,17 @@ function mappingAtSubstring(code, needle, mappings) {
 
 /**
  * @param {string} source
+ * @param {{ preserveParens?: boolean, boundaryTokens?: boolean }} [opts]
  */
-function mapped(source) {
+function mapped(source, opts = {}) {
 	const { ast, comments } = acornParse(source, {
+		preserveParens: opts.preserveParens,
 		sourceType: 'module',
 		jsxMode: false,
 		// @ts-expect-error test driver matches `test/esrap.test.js` parser options
 		fileExtension: 'ts'
 	});
-	const { code, map } = print(ast, ts({ comments }), {
+	const { code, map } = print(ast, ts({ comments, boundaryTokens: opts.boundaryTokens }), {
 		sourceMapSource: 'input.ts',
 		sourceMapContent: source,
 		sourceMapEncodeMappings: false
@@ -192,4 +194,74 @@ test('decorator-prefixed class falls back gracefully', () => {
 
 	expect(code).toContain('class');
 	expect(mappings.length).toBeGreaterThan(0);
+});
+
+test('source mappings anchor array and object brackets', () => {
+	{
+		const { source, code, mappings } = mapped(`const points = [];`, { boundaryTokens: true });
+
+		const seg_open = mappingAtSubstring(code, '[', mappings);
+		expect(seg_open[3]).toBe(source.indexOf('['));
+
+		const seg_close = mappingAtSubstring(code, ']', mappings);
+		expect(seg_close[3]).toBe(source.indexOf(']'));
+	}
+
+	{
+		const { source, code, mappings } = mapped(`const box = { a: 1 };`, { boundaryTokens: true });
+
+		const seg_open = mappingAtSubstring(code, '{', mappings);
+		expect(seg_open[3]).toBe(source.indexOf('{'));
+
+		const seg_close = mappingAtSubstring(code, '}', mappings);
+		expect(seg_close[3]).toBe(source.indexOf('}'));
+	}
+
+	{
+		// Destructured parameter defaults: the pattern's braces are its span.
+		const { source, code, mappings } = mapped(`const use = ({ a = 1 } = {}) => a;`, {
+			boundaryTokens: true
+		});
+
+		const seg_open = mappingAtSubstring(code, '{', mappings);
+		expect(seg_open[3]).toBe(source.indexOf('{'));
+	}
+});
+
+test('source mappings anchor unary operators', () => {
+	const { source, code, mappings } = mapped(`const neg = -value;`, { boundaryTokens: true });
+
+	const seg = mappingAtSubstring(code, '-', mappings);
+	expect(seg[3]).toBe(source.indexOf('-'));
+});
+
+test('source mappings anchor the closing tokens of calls and computed access', () => {
+	{
+		const { source, code, mappings } = mapped(`const item = items[index + 1];`, {
+			boundaryTokens: true
+		});
+
+		const seg_close = mappingAtSubstring(code, ']', mappings);
+		expect(seg_close[3]).toBe(source.indexOf(']'));
+	}
+
+	{
+		const { source, code, mappings } = mapped(`const dir = compute();`, { boundaryTokens: true });
+
+		const seg_close = mappingAtSubstring(code, ')', mappings);
+		expect(seg_close[3]).toBe(source.indexOf(')'));
+	}
+});
+
+test('source mappings anchor preserved parentheses', () => {
+	const { source, code, mappings } = mapped(`const x = (a - 1) % b;`, {
+		preserveParens: true,
+		boundaryTokens: true
+	});
+
+	const seg_open = mappingAtSubstring(code, '(', mappings);
+	expect(seg_open[3]).toBe(source.indexOf('('));
+
+	const seg_close = mappingAtSubstring(code, ')', mappings);
+	expect(seg_close[3]).toBe(source.indexOf(')'));
 });


### PR DESCRIPTION
Structural tokens — array/object brackets and braces, preserved parentheses, unary operators, and the closing tokens of calls and computed member access are written without location markers. Since source-map consumers attribute every generated character to the nearest PRECEDING segment, these characters (and any whitespace after them) are attributed to the previous token's source position, and a node whose source span begins or ends on one of them has no resolvable boundary position at all. Tools that map node-boundary positions back to source (e.g. Volar-style virtual-file tooling translating diagnostics) must then fail or degrade.

Add a `boundaryTokens` language option that anchors each such token with a one-character location at the node boundary it represents. Printed output is byte-identical; maps gain segments (measured ~13% mappings growth on a dense file), which is why the option is OFF by default - existing consumers are completely unaffected.