### PR TITLE
fix: only print `declare` on ambient function declarations

### DIFF
--- a/.changeset/soft-pumas-shake.md
+++ b/.changeset/soft-pumas-shake.md
@@ -1,0 +1,5 @@
+---
+'esrap': patch
+---
+
+fix: only print `declare` on ambient function declarations

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -1850,7 +1850,9 @@ export default (options = {}) => {
 		TSDeclareFunction(node, context) {
 			const kw = create_keyword_write(context, node);
 
-			kw('declare ');
+			// bodyless functions are either ambient declarations or overload
+			// signatures — only the former are written with `declare`
+			if (node.declare) kw('declare ');
 
 			if (node.async) {
 				kw('async ');

--- a/test/samples/ts-function-overloads/expected.ts
+++ b/test/samples/ts-function-overloads/expected.ts
@@ -1,0 +1,8 @@
+export function overloaded(value: string): string;
+export function overloaded(value: number): number;
+
+export function overloaded(value: any) {
+	return value;
+}
+
+declare function ambient(value: string): void;

--- a/test/samples/ts-function-overloads/expected.ts.map
+++ b/test/samples/ts-function-overloads/expected.ts.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": [
+    "input.js"
+  ],
+  "sourcesContent": [
+    "export function overloaded(value: string): string;\nexport function overloaded(value: number): number;\nexport function overloaded(value: any) {\n\treturn value;\n}\n\ndeclare function ambient(value: string): void;\n"
+  ],
+  "mappings": "AAAA,MAAM,CAAC,QAAQ,CAAC,UAAU,CAAC,KAAa,EAAN,MAAM,GAAG,MAAM;AACjD,MAAM,CAAC,QAAQ,CAAC,UAAU,CAAC,KAAa,EAAN,MAAM,GAAG,MAAM;;AACjD,MAAM,CAAC,QAAQ,CAAC,UAAU,CAAC,KAAU,EAAH,GAAG,EAAE,CAAC;CACvC,MAAM,CAAC,KAAK;AACb,CAAC;;AAED,QAAQ,AAAA,QAAQ,CAAC,OAAO,CAAC,KAAa,EAAN,MAAM,GAAG,IAAI"
+}

--- a/test/samples/ts-function-overloads/input.ts
+++ b/test/samples/ts-function-overloads/input.ts
@@ -1,0 +1,7 @@
+export function overloaded(value: string): string;
+export function overloaded(value: number): number;
+export function overloaded(value: any) {
+	return value;
+}
+
+declare function ambient(value: string): void;


### PR DESCRIPTION
A function declaration without a body is either an ambient declaration or an overload signature. `TSDeclareFunction` printed `declare` for both, so overload signatures came out as ambient ones.

`tsc` rejects the result — the signatures no longer belong to the implementation:

```ts
// before
export function overloaded(value: string): string;   →   export declare function overloaded(value: string): string;
export function overloaded(value: any) {                  export function overloaded(value: any) {
	return value;                                             return value;
}                                                         }
// TS2384: Overload signatures must all be ambient or non-ambient.
```

Under `export default` it is a syntax error rather than a type error (`export default declare function f(): void;;` — TS1005).

Now guarded on `node.declare`, matching the three other `declare` sites in the file (classes, class fields, variable declarations).
