### PR TITLE
fix: preserve character entities in JSX text

### DIFF
--- a/.changeset/lucky-jars-repeat.md
+++ b/.changeset/lucky-jars-repeat.md
@@ -1,0 +1,5 @@
+---
+'esrap': patch
+---
+
+fix: preserve character entities in JSX text

--- a/src/languages/tsx/index.js
+++ b/src/languages/tsx/index.js
@@ -72,7 +72,9 @@ export default (options) => ({
 	},
 
 	JSXText(node, context) {
-		context.write(node.value, node);
+		// `value` is decoded — re-emitting it would turn `&lt;`, `&gt;`, `&#123;`
+		// and `&#125;` back into characters that can't appear in JSX text
+		context.write(node.raw ?? node.value, node);
 	},
 
 	JSXAttribute(node, context) {

--- a/test/samples/jsx-entities/expected.jsx
+++ b/test/samples/jsx-entities/expected.jsx
@@ -1,0 +1,2 @@
+const comparison = <p>1 &lt; 2 &amp;&amp; 3 &gt; 2</p>;
+const braces = <p>&#123;not an expression&#125;</p>;

--- a/test/samples/jsx-entities/expected.jsx.map
+++ b/test/samples/jsx-entities/expected.jsx.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": [
+    "input.js"
+  ],
+  "sourcesContent": [
+    "const comparison = <p>1 &lt; 2 &amp;&amp; 3 &gt; 2</p>;\nconst braces = <p>&#123;not an expression&#125;</p>;\n"
+  ],
+  "mappings": "AAAA,MAAM,AAAA,UAAU,IAAI,CAAC,CAAC,4BAA4B,EAAE,CAAC;AACrD,MAAM,AAAA,MAAM,IAAI,CAAC,CAAC,6BAA6B,EAAE,CAAC"
+}

--- a/test/samples/jsx-entities/input.jsx
+++ b/test/samples/jsx-entities/input.jsx
@@ -1,0 +1,2 @@
+const comparison = <p>1 &lt; 2 &amp;&amp; 3 &gt; 2</p>;
+const braces = <p>&#123;not an expression&#125;</p>;


### PR DESCRIPTION
`JSXText` was printed from `node.value`, which is the *decoded* text. Re-emitting it turns character references back into characters that can't appear literally in JSX, so the output no longer parses.

```jsx
// before
const comparison = <p>1 &lt; 2 &amp;&amp; 3 &gt; 2</p>;   →   const comparison = <p>1 < 2 && 3 > 2</p>;
// TS1003: Identifier expected. / TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?

// after
const comparison = <p>1 &lt; 2 &amp;&amp; 3 &gt; 2</p>;   →   const comparison = <p>1 &lt; 2 &amp;&amp; 3 &gt; 2</p>;
```

Same for `&#123;` / `&#125;`, which become `{` and `}` (TS1381).

Printing `raw` instead, falling back to `value` for synthetic nodes that don't have one.
