### PR TITLE
fix: disambiguate arrow function type parameters in JSX

### DIFF
--- a/.changeset/olive-cases-invite.md
+++ b/.changeset/olive-cases-invite.md
@@ -1,0 +1,5 @@
+---
+'esrap': patch
+---
+
+fix: disambiguate arrow function type parameters in JSX

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ test/sandbox/_output.js
 
 expected.ts
 expected.jsx
+expected.tsx

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -208,10 +208,22 @@ function write_comment(comment, context) {
 }
 
 /**
+ * In a JSX file, an arrow function's `<T>` type parameter list is parsed as a
+ * JSX element instead. A trailing comma (`<T,>`) disambiguates it, and is only
+ * needed for a lone type parameter — a second parameter, a constraint or a
+ * default already rules JSX out. Modifiers (`const`, `in`, `out`) do not.
+ * @param {TSESTree.TSTypeParameterDeclaration} node
+ */
+function jsx_ambiguous_type_parameters(node) {
+	return node.params.length === 1 && !node.params[0].constraint && !node.params[0].default;
+}
+
+/**
  * @param {TSOptions} [options]
+ * @param {boolean} [jsx] set by the `tsx` language module
  * @returns {Visitors<TSESTree.Node>}
  */
-export default (options = {}) => {
+export default (options = {}, jsx = false) => {
 	const quote_char = options.quotes === 'double' ? '"' : "'";
 
 	const comments = options.comments ?? [];
@@ -1064,7 +1076,13 @@ export default (options = {}) => {
 			}
 
 			if (node.typeParameters) {
-				context.visit(node.typeParameters);
+				if (jsx && jsx_ambiguous_type_parameters(node.typeParameters)) {
+					context.write('<');
+					context.visit(node.typeParameters.params[0]);
+					context.write(',>');
+				} else {
+					context.visit(node.typeParameters);
+				}
 			}
 
 			context.write('(');

--- a/src/languages/tsx/index.js
+++ b/src/languages/tsx/index.js
@@ -8,7 +8,7 @@ import ts from '../ts/index.js';
  * @returns {Visitors<TSESTree.Node>}
  */
 export default (options) => ({
-	...ts(options),
+	...ts(options, true),
 
 	JSXElement(node, context) {
 		context.visit(node.openingElement);

--- a/test/esrap.test.js
+++ b/test/esrap.test.js
@@ -6,6 +6,7 @@ import { expect, test } from 'vitest';
 import { walk } from 'zimmerframe';
 import { print } from '../src/index.js';
 import { acornParse, oxcParse } from './common.js';
+import ts from '../src/languages/ts/index.js';
 import tsx from '../src/languages/tsx/index.js';
 import { describe } from 'node:test';
 
@@ -168,7 +169,7 @@ for (const dir of fs.readdirSync(`${__dirname}/samples`)) {
 					opts = { sourceMapSource: 'input.js', sourceMapContent: input_js };
 				}
 
-				const { code, map } = print(ast, tsx({ comments }), opts);
+				const { code, map } = print(ast, (jsxMode ? tsx : ts)({ comments }), opts);
 
 				const pDir = `${__dirname}/samples/${dir}/${parserName}`;
 				if (!fs.existsSync(pDir)) fs.mkdirSync(pDir, { recursive: true });

--- a/test/samples/tsx-generic-arrow/expected.tsx
+++ b/test/samples/tsx-generic-arrow/expected.tsx
@@ -1,0 +1,3 @@
+const identity = <T,>(value: T): T => value;
+const pair = <T, U>(a: T, b: U): [T, U] => [a, b];
+const element = <div>{identity('x')}</div>;

--- a/test/samples/tsx-generic-arrow/expected.tsx.map
+++ b/test/samples/tsx-generic-arrow/expected.tsx.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": [
+    "input.js"
+  ],
+  "sourcesContent": [
+    "const identity = <T,>(value: T): T => value;\nconst pair = <T, U>(a: T, b: U): [T, U] => [a, b];\nconst element = <div>{identity('x')}</div>;\n"
+  ],
+  "mappings": "AAAA,MAAM,AAAA,QAAQ,IAAI,CAAC,GAAG,KAAQ,EAAD,CAAC,GAAG,CAAC,IAAI,KAAK;AAC3C,MAAM,AAAA,IAAI,IAAI,CAAC,EAAE,CAAC,EAAE,CAAI,EAAD,CAAC,EAAE,CAAI,EAAD,CAAC,IAAI,CAAC,EAAE,CAAC,MAAM,CAAC,EAAE,CAAC;AAChD,MAAM,AAAA,OAAO,IAAI,GAAG,EAAE,QAAQ,CAAC,GAAG,IAAI,GAAG"
+}

--- a/test/samples/tsx-generic-arrow/input.tsx
+++ b/test/samples/tsx-generic-arrow/input.tsx
@@ -1,0 +1,3 @@
+const identity = <T,>(value: T): T => value;
+const pair = <T, U>(a: T, b: U): [T, U] => [a, b];
+const element = <div>{identity('x')}</div>;


### PR DESCRIPTION
In a JSX file, an arrow function's `<T>` type parameter list is parsed as the start of a JSX element. The trailing comma that disambiguates it was dropped, so generic arrow functions printed with `esrap/languages/tsx` no longer compile:

```tsx
// before
const identity = <T,>(value: T): T => value;   →   const identity = <T>(value: T): T => value;
// TS17008: JSX element 'T' has no corresponding closing tag.

// after
const identity = <T,>(value: T): T => value;   →   const identity = <T,>(value: T): T => value;
```

The comma is only added where the list is actually ambiguous — a second parameter, a constraint or a default already rules JSX out, so `<T, U>`, `<T extends object>` and `<T = string>` are left alone. Modifiers (`const`, `in`, `out`) do *not* disambiguate, so `<const T>` gets the comma too.

Two supporting changes:

- `ts()` takes an internal second argument set by the `tsx` module, so this only affects JSX output. The public signature is unchanged.
- `esrap.test.js` printed every sample with `tsx()`, including the `.ts` ones — it now picks the module matching the sample's `jsxMode`, so `ts-arrow-function-types` keeps printing plain `<T>`.
