### PR TITLE
fix: keep JSX comments inside their expression container

### DIFF
--- a/.changeset/tame-poems-cheat.md
+++ b/.changeset/tame-poems-cheat.md
@@ -1,0 +1,5 @@
+---
+'esrap': patch
+---
+
+fix: keep JSX comments inside their expression container

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -1046,6 +1046,14 @@ export default (options = {}) => {
 
 			visit(node);
 
+			// a JSX empty expression prints nothing and exists only to hold the
+			// comments inside `{...}`. Flush them here, otherwise they are written
+			// by whichever node comes next — after the closing brace, where they
+			// are JSX text rather than a comment
+			if (node.type === 'JSXEmptyExpression' && node.loc) {
+				flush_comments_until(context, null, node.loc.end, false);
+			}
+
 			write_additional_comments(context, options.getTrailingComments?.(node), 'trailing');
 		},
 

--- a/test/samples/jsx-comment/expected.jsx
+++ b/test/samples/jsx-comment/expected.jsx
@@ -1,0 +1,5 @@
+const list = <ul>
+		{/* items go here */}
+		{items}
+		{/* nothing after this */}
+	</ul>;

--- a/test/samples/jsx-comment/expected.jsx.map
+++ b/test/samples/jsx-comment/expected.jsx.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": [
+    "input.js"
+  ],
+  "sourcesContent": [
+    "const list = (\n\t<ul>\n\t\t{/* items go here */}\n\t\t{items}\n\t\t{/* nothing after this */}\n\t</ul>\n);\n"
+  ],
+  "mappings": "AAAA,MAAM,AAAA,IAAI,IACR,EAAE,CAAC;EACH,qBAAqB;EACrB,CAAC,KAAK,CAAC;EACP,0BAA0B;CAC3B,EAAE,EAAE"
+}

--- a/test/samples/jsx-comment/input.jsx
+++ b/test/samples/jsx-comment/input.jsx
@@ -1,0 +1,7 @@
+const list = (
+	<ul>
+		{/* items go here */}
+		{items}
+		{/* nothing after this */}
+	</ul>
+);


### PR DESCRIPTION
`JSXEmptyExpression` prints nothing, so a comment that is the only thing inside `{...}` was still pending when the braces closed. It then got flushed by whichever node came next — outside the container, where it is JSX text rather than a comment, and so ends up rendered on the page.

```jsx
// before
<ul>                              <ul>
	{/* items go here */}     →   		{}/* items go here */
	{items}                       		{items}
</ul>                             </ul>

// after
<ul>                              <ul>
	{/* items go here */}     →   		{/* items go here */}
	{items}                       		{items}
</ul>                             </ul>
```

The comment buffer lives in the `ts` module's closure, so the flush happens in the shared `_` visitor rather than in the JSX visitors.
