### PR TITLE
fix: don't drop newlines when `indent` is an empty string

### DIFF
--- a/.changeset/silver-moons-tap.md
+++ b/.changeset/silver-moons-tap.md
@@ -1,0 +1,5 @@
+---
+'esrap': patch
+---
+
+fix: don't drop newlines when `indent` is an empty string

--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,8 @@ export function print(node, visitors, opts = {}) {
 			} else if (command === indent) {
 				current_newline += indent_str;
 			} else if (command === dedent) {
-				current_newline = current_newline.slice(0, -indent_str.length);
+				// `slice(0, -0)` would return an empty string, dropping the newline
+				current_newline = current_newline.slice(0, current_newline.length - indent_str.length);
 			}
 
 			return;

--- a/test/indent.test.js
+++ b/test/indent.test.js
@@ -8,6 +8,16 @@ import ts from '../src/languages/ts/index.js';
 
 const test_code = "const foo = () => { const bar = 'baz' }";
 
+const nested_test_code = `
+function foo() {
+	if (bar) {
+		baz();
+	}
+	// a comment
+	qux();
+}
+`;
+
 test('default indent type is tab', () => {
 	const { ast } = acornParse(test_code);
 	const code = print(ast, ts()).code;
@@ -38,5 +48,21 @@ test('four space indent', () => {
 		"const foo = () => {
 		    const bar = 'baz';
 		};"
+	`);
+});
+
+test('empty indent still emits newlines', () => {
+	const { ast, comments } = acornParse(nested_test_code);
+	const code = print(ast, ts({ comments }), { indent: '' }).code;
+
+	expect(code).toMatchInlineSnapshot(`
+		"function foo() {
+		if (bar) {
+		baz();
+		}
+
+		// a comment
+		qux();
+		}"
 	`);
 });


### PR DESCRIPTION
`dedent` computed the new indentation with `slice(0, -indent_str.length)`. When `indent` is `''` that is `slice(0, -0)` — which is `slice(0, 0)`, i.e. the empty string — so the first `dedent` wiped the newline and every subsequent newline emitted nothing.

The output still parses, which is what makes it easy to miss: a line comment silently swallows whatever followed it.

```js
print(ast, ts({ comments }), { indent: '' })

// before                          // after
function foo() {                   function foo() {
if (bar) {                         if (bar) {
baz();}                            baz();
// a commentqux();}                }
//        ^ `qux()` is gone
                                   // a comment
                                   qux();
                                   }
```

`indent` is typed as `string` with no restriction, so `''` is a legal value.
