### PR TITLE
fix: preserve definite assignment assertions on variable declarations

### DIFF
--- a/.changeset/great-eyes-guess.md
+++ b/.changeset/great-eyes-guess.md
@@ -1,0 +1,5 @@
+---
+'esrap': patch
+---
+
+fix: preserve definite assignment assertions on variable declarations

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -1339,6 +1339,8 @@ export default (options = {}) => {
 
 			// optional parameters (`a?: T`) carry `optional` on the identifier
 			if (node.optional) context.write('?');
+			// definite assignment (`let x!: T`) — see `handle_var_declarator`
+			else if (/** @type {any} */ (node).definite) context.write('!');
 
 			if (node.typeAnnotation) context.visit(node.typeAnnotation);
 		},
@@ -2689,7 +2691,9 @@ function same_module_name(a, b) {
  * @param {boolean} no_in
  */
 function handle_var_declarator(node, context, no_in) {
-	context.visit(node.id);
+	// `definite` sits on the declarator, but `!` belongs between the name and the
+	// type annotation — both of which are written by the identifier's own visitor
+	context.visit(node.definite ? /** @type {any} */ ({ ...node.id, definite: true }) : node.id);
 
 	if (node.init) {
 		context.write(' = ');

--- a/test/samples/ts-definite-assignment/expected.ts
+++ b/test/samples/ts-definite-assignment/expected.ts
@@ -1,0 +1,8 @@
+let value!: number;
+
+class Container {
+	field!: number;
+	accessor other!: string;
+}
+
+export { value, Container };

--- a/test/samples/ts-definite-assignment/expected.ts.map
+++ b/test/samples/ts-definite-assignment/expected.ts.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": [
+    "input.js"
+  ],
+  "sourcesContent": [
+    "let value!: number;\n\nclass Container {\n\tfield!: number;\n\taccessor other!: string;\n}\n\nexport { value, Container };\n"
+  ],
+  "mappings": "AAAA,IAAI,AAAA,KAAc,GAAN,MAAM;;AAElB,MAAM,AAAA,SAAS,CAAC,CAAC;CAChB,KAAK,GAAG,MAAM;CACd,SAAS,AAAA,KAAK,GAAG,MAAM;AACxB,CAAC;;AAED,OAAO,EAAE,KAAK,EAAE,SAAS"
+}

--- a/test/samples/ts-definite-assignment/input.ts
+++ b/test/samples/ts-definite-assignment/input.ts
@@ -1,0 +1,8 @@
+let value!: number;
+
+class Container {
+	field!: number;
+	accessor other!: string;
+}
+
+export { value, Container };


### PR DESCRIPTION
Fixes #95.

`definite` sits on the `VariableDeclarator`, but the type annotation sits on the identifier — and the identifier's visitor writes the name and the annotation together, so there was nowhere for `handle_var_declarator` to put the `!`. It was dropped:

```ts
// before
let value!: number;   →   let value: number;
// TS2454: Variable 'value' is used before being assigned.

// after
let value!: number;   →   let value!: number;
```

The identifier visitor now writes `!` the same way it already writes `?` for optional parameters, and `handle_var_declarator` passes `definite` down to it.

The class property half of the issue already prints correctly (`PropertyDefinition` owns its own type annotation, so it can write `!` itself) — the test sample covers `field!: number` and `accessor other!: string` to lock that in.
