### PR TITLE
fix: preserve type-level syntax that was being dropped when printing

### DIFF
--- a/.changeset/wild-jokes-listen.md
+++ b/.changeset/wild-jokes-listen.md
@@ -1,0 +1,5 @@
+---
+'esrap': patch
+---
+
+fix: preserve type-level syntax that was being dropped when printing

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ test/sandbox/_output.js
 
 expected.ts
 expected.jsx
+expected.tsx

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -2086,6 +2086,11 @@ export default (options = {}) => {
 		TSTypeQuery(node, context) {
 			context.write('typeof ');
 			context.visit(node.exprName);
+
+			// instantiation expression (`typeof foo<string>`)
+			if (node.typeArguments) {
+				context.visit(node.typeArguments);
+			}
 		},
 
 		TSClassImplements(node, context) {
@@ -2169,6 +2174,11 @@ export default (options = {}) => {
 		},
 
 		TSMethodSignature(node, context) {
+			// accessor signatures (`get x(): string`, `set x(value: string)`)
+			if (node.kind === 'get' || node.kind === 'set') {
+				write_keyword(context, node, node.kind, ' ');
+			}
+
 			if (node.computed) context.write('[', token_before(node.key.loc?.start));
 			context.visit(node.key);
 			if (node.computed) context.write(']', token_at(node.key.loc?.end));
@@ -2204,6 +2214,8 @@ export default (options = {}) => {
 
 		TSNamedTupleMember(node, context) {
 			context.visit(node.label);
+			// optional element (`[a?: string]`)
+			if (node.optional) context.write('?');
 			context.write(': ');
 			context.visit(node.elementType);
 		},

--- a/src/languages/tsx/index.js
+++ b/src/languages/tsx/index.js
@@ -35,6 +35,11 @@ export default (options) => ({
 
 		context.visit(node.name);
 
+		// explicit type arguments (`<Comp<string> ... />`)
+		if (node.typeArguments) {
+			context.visit(node.typeArguments);
+		}
+
 		for (const attribute of node.attributes) {
 			context.write(' ');
 			context.visit(attribute);

--- a/test/samples/ts-type-level-syntax/expected.ts
+++ b/test/samples/ts-type-level-syntax/expected.ts
@@ -1,0 +1,5 @@
+type Tuple = [required: string, optional?: number, ...rest: boolean[]];
+
+interface Accessors { get value(): string; set value(next: string); method(): void }
+
+type Instantiated = typeof identity<string>;

--- a/test/samples/ts-type-level-syntax/expected.ts.map
+++ b/test/samples/ts-type-level-syntax/expected.ts.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": [
+    "input.js"
+  ],
+  "sourcesContent": [
+    "type Tuple = [required: string, optional?: number, ...rest: boolean[]];\n\ninterface Accessors {\n\tget value(): string;\n\tset value(next: string);\n\tmethod(): void;\n}\n\ntype Instantiated = typeof identity<string>;\n"
+  ],
+  "mappings": "KAAK,KAAK,IAAI,QAAQ,EAAE,MAAM,EAAE,QAAQ,GAAG,MAAM,KAAK,IAAI,EAAE,OAAO;;UAEzD,SAAS,GAClB,GAAG,CAAC,KAAK,IAAI,MAAM,EACnB,GAAG,CAAC,KAAK,CAAC,IAAY,EAAN,MAAM,GACtB,MAAM,IAAI,IAAI;;KAGV,YAAY,UAAU,QAAQ,CAAC,MAAM"
+}

--- a/test/samples/ts-type-level-syntax/input.ts
+++ b/test/samples/ts-type-level-syntax/input.ts
@@ -1,0 +1,9 @@
+type Tuple = [required: string, optional?: number, ...rest: boolean[]];
+
+interface Accessors {
+	get value(): string;
+	set value(next: string);
+	method(): void;
+}
+
+type Instantiated = typeof identity<string>;

--- a/test/samples/tsx-element-type-arguments/expected.tsx
+++ b/test/samples/tsx-element-type-arguments/expected.tsx
@@ -1,0 +1,3 @@
+const list = <List<string> items={items} />;
+const nested = <Table<Row, Column>>{children}</Table>;
+const plain = <div className="x" />;

--- a/test/samples/tsx-element-type-arguments/expected.tsx.map
+++ b/test/samples/tsx-element-type-arguments/expected.tsx.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": [
+    "input.js"
+  ],
+  "sourcesContent": [
+    "const list = <List<string> items={items} />;\nconst nested = <Table<Row, Column>>{children}</Table>;\nconst plain = <div className=\"x\" />;\n"
+  ],
+  "mappings": "AAAA,MAAM,AAAA,IAAI,IAAI,IAAI,CAAC,MAAM,EAAE,KAAK,EAAE,KAAK;AACvC,MAAM,AAAA,MAAM,IAAI,KAAK,CAAC,GAAG,EAAE,MAAM,GAAG,QAAQ,GAAG,KAAK;AACpD,MAAM,AAAA,KAAK,IAAI,GAAG,CAAC,SAAS,CAAC,GAAG"
+}

--- a/test/samples/tsx-element-type-arguments/input.tsx
+++ b/test/samples/tsx-element-type-arguments/input.tsx
@@ -1,0 +1,3 @@
+const list = <List<string> items={items} />;
+const nested = <Table<Row, Column>>{children}</Table>;
+const plain = <div className="x" />;


### PR DESCRIPTION
Four visitors carried type-level information on the node but never printed it. Each is a silent change of meaning — the output still parses, so nothing surfaces until the types are wrong.

**Optional tuple elements** — `TSNamedTupleMember.optional`

```ts
type Tuple = [required: string, optional?: number];   →   type Tuple = [required: string, optional: number];
```

**Accessor signatures** — `TSMethodSignature.kind`

```ts
interface Accessors {                interface Accessors {
	get value(): string;         →   	value(): string;
	set value(next: string);         	value(next: string);
}                                    }
```

Two accessors become two call signatures for the same method — a different (and, with differing parameter/return types, invalid) interface.

**Instantiation expressions in `typeof`** — `TSTypeQuery.typeArguments`

```ts
type Instantiated = typeof identity<string>;   →   type Instantiated = typeof identity;
```

**Explicit type arguments on JSX elements** — `JSXOpeningElement.typeArguments`

```tsx
const list = <List<string> items={items} />;   →   const list = <List items={items} />;
```

Both `@sveltejs/acorn-typescript` and `oxc-parser` populate all four properties under the same names, and both now produce identical output for each case.

One incidental change: `expected.tsx` is added to `.prettierignore`, next to the `expected.ts` and `expected.jsx` entries that were already there. The snapshot harness writes these files without a trailing newline, so lint fails on the first `.tsx` sample in the repo. #155 adds the same line for the same reason — whichever lands second will need that hunk dropped.
