### PR TITLE
fix: print `declare` on ambient interfaces and type aliases

### DIFF
--- a/.changeset/tidy-hounds-write.md
+++ b/.changeset/tidy-hounds-write.md
@@ -1,0 +1,5 @@
+---
+'esrap': patch
+---
+
+fix: print `declare` on ambient interfaces and type aliases

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -2367,6 +2367,7 @@ export default (options = {}) => {
 		},
 
 		TSInterfaceDeclaration(node, context) {
+			if (node.declare) context.write('declare ');
 			context.write('interface ');
 			context.visit(node.id);
 			if (node.typeParameters) context.visit(node.typeParameters);
@@ -2411,6 +2412,7 @@ export default (options = {}) => {
 		},
 
 		TSTypeAliasDeclaration(node, context) {
+			if (node.declare) context.write('declare ');
 			context.write('type ');
 			context.visit(node.id);
 			if (node.typeParameters) context.visit(node.typeParameters);

--- a/test/samples/ts-declare-interface-type/expected.ts
+++ b/test/samples/ts-declare-interface-type/expected.ts
@@ -1,0 +1,9 @@
+declare interface Ambient { value: string }
+
+declare type Alias = string;
+
+export declare interface Exported<T> extends Ambient { other: T }
+
+interface Plain { value: string }
+
+type PlainAlias = number;

--- a/test/samples/ts-declare-interface-type/expected.ts.map
+++ b/test/samples/ts-declare-interface-type/expected.ts.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": [
+    "input.js"
+  ],
+  "sourcesContent": [
+    "declare interface Ambient {\n\tvalue: string;\n}\n\ndeclare type Alias = string;\n\nexport declare interface Exported<T> extends Ambient {\n\tother: T;\n}\n\ninterface Plain {\n\tvalue: string;\n}\n\ntype PlainAlias = number;\n"
+  ],
+  "mappings": "kBAAkB,OAAO,GACxB,KAAK,EAAE,MAAM;;aAGD,KAAK,GAAG,MAAM;;AAE3B,MAAM,mBAAmB,QAAQ,CAAC,CAAC,UAAU,OAAO,GACnD,KAAK,EAAE,CAAC;;UAGC,KAAK,GACd,KAAK,EAAE,MAAM;;KAGT,UAAU,GAAG,MAAM"
+}

--- a/test/samples/ts-declare-interface-type/input.ts
+++ b/test/samples/ts-declare-interface-type/input.ts
@@ -1,0 +1,15 @@
+declare interface Ambient {
+	value: string;
+}
+
+declare type Alias = string;
+
+export declare interface Exported<T> extends Ambient {
+	other: T;
+}
+
+interface Plain {
+	value: string;
+}
+
+type PlainAlias = number;


### PR DESCRIPTION
`TSInterfaceDeclaration` and `TSTypeAliasDeclaration` were the last two `declare`-capable declarations that dropped the modifier:

```ts
// before
declare interface Ambient {   →   interface Ambient {
	value: string;                	value: string;
}                                 }

declare type Alias = string;  →   type Alias = string;
```

Classes, enums, variables, functions, namespaces and modules all print it already — enums since #151, functions since #153 — so this is the tail of that group.

Both are round-trip fidelity rather than a compile break: `declare` is redundant on an interface or a type alias, since both are always ambient, and the output type-checks either way. What it does affect is anything that diffs printed output against its input, and consistency with the other seven declaration kinds.

`node.declare` is set by both `@sveltejs/acorn-typescript` and `oxc-parser`. Written with `context.write`, matching `TSEnumDeclaration` — using `create_keyword_write` here would add source-map anchors to every existing interface and type alias in the samples, which is a separate concern.

The test sample covers the ambient forms, `export declare interface`, and the plain forms as a regression guard.
