### PR TITLE
fix: preserve missing type annotations and arguments (#174)

### DIFF
--- a/.changeset/six-pianos-know.md
+++ b/.changeset/six-pianos-know.md
@@ -2,4 +2,4 @@
 'esrap': patch
 ---
 
-fix: preserve type arguments on tagged templates, array pattern annotations, and template literal type quasis (fixes #174)
+fix: preserve type arguments on tagged templates, array pattern annotations, and template literal type quasis

--- a/.changeset/six-pianos-know.md
+++ b/.changeset/six-pianos-know.md
@@ -1,0 +1,5 @@
+---
+'esrap': patch
+---
+
+fix: preserve type arguments on tagged templates, array pattern annotations, and template literal type quasis (fixes #174)

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -594,6 +594,7 @@ export default (options = {}) => {
 				false
 			);
 			context.write(']', token_before(node.loc?.end));
+			if ('typeAnnotation' in node && node.typeAnnotation) context.visit(node.typeAnnotation);
 		},
 
 		/**
@@ -2066,7 +2067,16 @@ export default (options = {}) => {
 
 				if (/\n/.test(raw)) context.multiline = true;
 			}
-			context.write('`');
+			const raw = quasis[quasis.length - 1].value.raw;
+			context.write(raw + '`');
+			if (/\n/.test(raw)) context.multiline = true;
+		},
+
+		// @ts-expect-error not in TSESTree types
+		TSJSDocNullableType(node, context) {
+			if (!node.postfix) context.write('?');
+			context.visit(node.typeAnnotation);
+			if (node.postfix) context.write('?');
 		},
 
 		TSParameterProperty(node, context) {

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -1779,6 +1779,7 @@ export default (options = {}) => {
 				/** @type {string} */ (node.tag.type) === 'ChainExpression' ||
 				EXPRESSIONS_PRECEDENCE[node.tag.type] < EXPRESSIONS_PRECEDENCE.CallExpression;
 			maybe_wrap(context, node.tag, wrap);
+			if (node.typeArguments) context.visit(node.typeArguments);
 			context.visit(node.quasi);
 		},
 

--- a/test/compat.test.js
+++ b/test/compat.test.js
@@ -36,3 +36,34 @@ test('acorn TS printer preserves module and mapped-type keywords', () => {
 
 	expect(code).toBe('declare module "svelte" {\n}\n\ntype M = {[K in keyof JSON]: K};');
 });
+
+test('TSJSDocNullableType prefix and postfix', () => {
+	/** @type {any} */
+	const ast = {
+		type: 'Program',
+		body: [
+			{
+				type: 'TSTypeAliasDeclaration',
+				id: { type: 'Identifier', name: 'A' },
+				typeAnnotation: {
+					type: 'TSJSDocNullableType',
+					typeAnnotation: { type: 'TSNumberKeyword' },
+					postfix: false
+				}
+			},
+			{
+				type: 'TSTypeAliasDeclaration',
+				id: { type: 'Identifier', name: 'B' },
+				typeAnnotation: {
+					type: 'TSJSDocNullableType',
+					typeAnnotation: { type: 'TSNumberKeyword' },
+					postfix: true
+				}
+			}
+		],
+		sourceType: 'module'
+	};
+
+	const { code } = print(ast, ts());
+	expect(code).toBe('type A = ?number;\ntype B = number?;');
+});

--- a/test/samples/ts-array-patterns/expected.ts
+++ b/test/samples/ts-array-patterns/expected.ts
@@ -1,0 +1,5 @@
+const [a, b]: string[] = ['foo', 'bar'];
+
+function fn([first, second]: number[]) {
+	return first + second;
+}

--- a/test/samples/ts-array-patterns/expected.ts.map
+++ b/test/samples/ts-array-patterns/expected.ts.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": [
+    "input.js"
+  ],
+  "sourcesContent": [
+    "const [a, b]: string[] = ['foo', 'bar'];\n\nfunction fn([first, second]: number[]) {\n\treturn first + second;\n}\n"
+  ],
+  "mappings": "AAAA,MAAM,CAAC,CAAC,EAAE,CAAC,GAAG,MAAM,MAAM,KAAK,EAAE,KAAK;;AAEtC,QAAQ,CAAC,EAAE,EAAE,KAAK,EAAE,MAAM,GAAG,MAAM,IAAI,CAAC;CACvC,MAAM,CAAC,KAAK,GAAG,MAAM;AACtB,CAAC"
+}

--- a/test/samples/ts-array-patterns/input.ts
+++ b/test/samples/ts-array-patterns/input.ts
@@ -1,0 +1,5 @@
+const [a, b]: string[] = ['foo', 'bar'];
+
+function fn([first, second]: number[]) {
+	return first + second;
+}

--- a/test/samples/ts-tagged-template/expected.ts
+++ b/test/samples/ts-tagged-template/expected.ts
@@ -1,0 +1,3 @@
+sql<string[]>`SELECT * FROM table`;
+
+const res = tag<A, B>`hello ${world}`;

--- a/test/samples/ts-tagged-template/expected.ts.map
+++ b/test/samples/ts-tagged-template/expected.ts.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": [
+    "input.js"
+  ],
+  "sourcesContent": [
+    "sql<string[]>`SELECT * FROM table`;\nconst res = tag<A, B>`hello ${world}`;\n"
+  ],
+  "mappings": "AAAA,GAAG,CAAC,MAAM;;AACV,MAAM,AAAA,GAAG,GAAG,GAAG,CAAC,CAAC,EAAE,CAAC,UAAU,KAAK"
+}

--- a/test/samples/ts-tagged-template/input.ts
+++ b/test/samples/ts-tagged-template/input.ts
@@ -1,0 +1,2 @@
+sql<string[]>`SELECT * FROM table`;
+const res = tag<A, B>`hello ${world}`;

--- a/test/samples/ts-template-literal-types/expected.ts
+++ b/test/samples/ts-template-literal-types/expected.ts
@@ -1,0 +1,4 @@
+type Event = `on${string}`;
+type Path<T extends string> = `/${T}/index.html`;
+type Plain = `static_string`;
+type Multi<A extends string, B extends string> = `prefix_${A}_middle_${B}_suffix`;

--- a/test/samples/ts-template-literal-types/expected.ts.map
+++ b/test/samples/ts-template-literal-types/expected.ts.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": [
+    "input.js"
+  ],
+  "sourcesContent": [
+    "type Event = `on${string}`;\ntype Path<T extends string> = `/${T}/index.html`;\ntype Plain = `static_string`;\ntype Multi<A extends string, B extends string> = `prefix_${A}_middle_${B}_suffix`;\n"
+  ],
+  "mappings": "KAAK,KAAK,QAAQ,MAAM;KACnB,IAAI,CAAC,CAAgB,SAAN,MAAM,QAAQ,CAAC;KAC9B,KAAK;KACL,KAAK,CAAC,CAAgB,SAAN,MAAM,EAAE,CAAgB,SAAN,MAAM,cAAc,CAAC,WAAW,CAAC"
+}

--- a/test/samples/ts-template-literal-types/input.ts
+++ b/test/samples/ts-template-literal-types/input.ts
@@ -1,0 +1,4 @@
+type Event = `on${string}`;
+type Path<T extends string> = `/${T}/index.html`;
+type Plain = `static_string`;
+type Multi<A extends string, B extends string> = `prefix_${A}_middle_${B}_suffix`;


### PR DESCRIPTION
Fixes #174 

Originally, I ran into an issue with the sv CLI's migration for Sveltekit 3 where generic type arguments on my drizzle queries were being dropped.

Found issue 174 which noted three other locations which would also result in dropped type attributes during migration.

### Changes
- **Tagged templates**: Keep type arguments so they aren't stripped (e.g. ``tag<Type>`...` ``).
- **Array destructuring**: Keep type annotations on array patterns (e.g. `[a, b]: string[]`).
- **Template literal types**: Don't drop string prefixes/suffixes in template types (e.g. `` `${string}_sfx` ``).
- **JSDoc nullable types**: Add missing support for printing `?T` / `T?`.