### PR TITLE
fix: don't treat JSDoc type casts on param defaults and named function ids as casts

### DIFF
--- a/.changeset/fix-jsdoc-cast-param-bindings.md
+++ b/.changeset/fix-jsdoc-cast-param-bindings.md
@@ -1,0 +1,5 @@
+---
+'esrap': patch
+---
+
+fix: don't treat JSDoc `@type` comments re-anchored to parameter defaults or named function ids as type casts

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -102,6 +102,24 @@ function track_bindings(nodes) {
 }
 
 /**
+ * Tracks function parameters as binding positions. A param with a default value
+ * is an `AssignmentPattern`; the binding is its `left`, not the pattern itself —
+ * the comment flush that decides whether a JSDoc `@type` cast gets wrapped in
+ * parentheses happens on the identifier's own visit.
+ * @param {(object | null | undefined)[] | null | undefined} params
+ * @returns {void}
+ */
+function track_param_bindings(params) {
+	if (!params) return;
+	track_bindings(params);
+	for (const param of params) {
+		if (/** @type {any} */ (param)?.type === 'AssignmentPattern') {
+			track_binding(/** @type {any} */ (param).left);
+		}
+	}
+}
+
+/**
  * Writes `keyword` bounded by source map locations for the exact character span,
  * so breakpoints line up on keywords (not only identifiers and braces).
  *
@@ -844,13 +862,15 @@ export default (options = {}) => {
 				}
 			}
 
+			if (node.id) track_binding(node.id);
+
 			if (node.id) context.visit(node.id);
 
 			if (node.typeParameters) {
 				context.visit(node.typeParameters);
 			}
 
-			track_bindings(node.params);
+			track_param_bindings(node.params);
 			context.write('(');
 			sequence(context, node.params, (node.returnType ?? node.body).loc?.start ?? null, false);
 			context.write(')');
@@ -912,7 +932,7 @@ export default (options = {}) => {
 			// @ts-expect-error `typeParameters` lives on the method node, not its value
 			if (node.typeParameters) context.visit(node.typeParameters);
 
-			track_bindings(node.value.params);
+			track_param_bindings(node.value.params);
 			context.write('(');
 			sequence(
 				context,
@@ -1036,7 +1056,7 @@ export default (options = {}) => {
 			}
 
 			// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
-			track_bindings(node.parameters ?? node.params);
+			track_param_bindings(node.parameters ?? node.params);
 			context.write('(');
 			sequence(
 				context,
@@ -1067,7 +1087,7 @@ export default (options = {}) => {
 			if (node.typeParameters) context.visit(node.typeParameters);
 
 			// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
-			track_bindings(node.parameters ?? node.params);
+			track_param_bindings(node.parameters ?? node.params);
 			context.write('(');
 			sequence(
 				context,
@@ -1139,7 +1159,7 @@ export default (options = {}) => {
 				context.visit(node.typeParameters);
 			}
 
-			track_bindings(node.params);
+			track_param_bindings(node.params);
 			context.write('(');
 			sequence(context, node.params, (node.returnType ?? node.body).loc?.start ?? null, false);
 			context.write(')');
@@ -1656,7 +1676,7 @@ export default (options = {}) => {
 				if (node.computed) context.write('[', token_before(node.key.loc?.start));
 				context.visit(node.key);
 				if (node.computed) context.write(']', token_at(node.key.loc?.end));
-				track_bindings(node.value.params);
+				track_param_bindings(node.value.params);
 				context.write('(');
 				sequence(
 					context,
@@ -1951,7 +1971,7 @@ export default (options = {}) => {
 				context.visit(node.typeParameters);
 			}
 
-			track_bindings(node.params);
+			track_param_bindings(node.params);
 			context.write('(');
 			sequence(context, node.params, node.returnType?.loc?.start ?? node.loc?.end ?? null, false);
 			context.write(')');
@@ -2279,7 +2299,7 @@ export default (options = {}) => {
 			}
 
 			// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
-			track_bindings(node.parameters ?? node.params);
+			track_param_bindings(node.parameters ?? node.params);
 			context.write('(');
 			sequence(
 				context,

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -84,12 +84,34 @@ const OPERATOR_PRECEDENCE = {
 const BINDINGS = new WeakSet();
 
 /**
- * Marks a node as occupying a binding position.
+ * Marks a binding pattern and all of its nested binding targets.
  * @param {object | null | undefined} node
  * @returns {void}
  */
 function track_binding(node) {
-	if (node && typeof node === 'object') BINDINGS.add(node);
+	if (!node || typeof node !== 'object') return;
+
+	BINDINGS.add(node);
+
+	switch (/** @type {any} */ (node).type) {
+		case 'AssignmentPattern':
+			track_binding(/** @type {any} */ (node).left);
+			break;
+		case 'RestElement':
+			track_binding(/** @type {any} */ (node).argument);
+			break;
+		case 'ArrayPattern':
+			track_bindings(/** @type {any} */ (node).elements);
+			break;
+		case 'ObjectPattern':
+			for (const property of /** @type {any} */ (node).properties) {
+				track_binding(property.type === 'Property' ? property.value : property);
+			}
+			break;
+		case 'TSParameterProperty':
+			track_binding(/** @type {any} */ (node).parameter);
+			break;
+	}
 }
 
 /**
@@ -99,24 +121,6 @@ function track_binding(node) {
  */
 function track_bindings(nodes) {
 	if (nodes) for (const node of nodes) track_binding(node);
-}
-
-/**
- * Tracks function parameters as binding positions. A param with a default value
- * is an `AssignmentPattern`; the binding is its `left`, not the pattern itself —
- * the comment flush that decides whether a JSDoc `@type` cast gets wrapped in
- * parentheses happens on the identifier's own visit.
- * @param {(object | null | undefined)[] | null | undefined} params
- * @returns {void}
- */
-function track_param_bindings(params) {
-	if (!params) return;
-	track_bindings(params);
-	for (const param of params) {
-		if (/** @type {any} */ (param)?.type === 'AssignmentPattern') {
-			track_binding(/** @type {any} */ (param).left);
-		}
-	}
 }
 
 /**
@@ -870,7 +874,7 @@ export default (options = {}) => {
 				context.visit(node.typeParameters);
 			}
 
-			track_param_bindings(node.params);
+			track_bindings(node.params);
 			context.write('(');
 			sequence(context, node.params, (node.returnType ?? node.body).loc?.start ?? null, false);
 			context.write(')');
@@ -932,7 +936,7 @@ export default (options = {}) => {
 			// @ts-expect-error `typeParameters` lives on the method node, not its value
 			if (node.typeParameters) context.visit(node.typeParameters);
 
-			track_param_bindings(node.value.params);
+			track_bindings(node.value.params);
 			context.write('(');
 			sequence(
 				context,
@@ -1060,7 +1064,7 @@ export default (options = {}) => {
 			}
 
 			// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
-			track_param_bindings(node.parameters ?? node.params);
+			track_bindings(node.parameters ?? node.params);
 			context.write('(');
 			sequence(
 				context,
@@ -1091,7 +1095,7 @@ export default (options = {}) => {
 			if (node.typeParameters) context.visit(node.typeParameters);
 
 			// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
-			track_param_bindings(node.parameters ?? node.params);
+			track_bindings(node.parameters ?? node.params);
 			context.write('(');
 			sequence(
 				context,
@@ -1161,7 +1165,7 @@ export default (options = {}) => {
 				context.visit(node.typeParameters);
 			}
 
-			track_param_bindings(node.params);
+			track_bindings(node.params);
 			context.write('(');
 			sequence(context, node.params, (node.returnType ?? node.body).loc?.start ?? null, false);
 			context.write(')');
@@ -1679,7 +1683,7 @@ export default (options = {}) => {
 				context.visit(node.key);
 				if (node.computed) context.write(']', token_at(node.key.loc?.end));
 				if (node.value.typeParameters) context.visit(node.value.typeParameters);
-				track_param_bindings(node.value.params);
+				track_bindings(node.value.params);
 				context.write('(');
 				sequence(
 					context,
@@ -1967,6 +1971,7 @@ export default (options = {}) => {
 
 			if (node.id) {
 				context.write(' ');
+				track_binding(node.id);
 				context.visit(node.id);
 			}
 
@@ -1974,7 +1979,7 @@ export default (options = {}) => {
 				context.visit(node.typeParameters);
 			}
 
-			track_param_bindings(node.params);
+			track_bindings(node.params);
 			context.write('(');
 			sequence(context, node.params, node.returnType?.loc?.start ?? node.loc?.end ?? null, false);
 			context.write(')');
@@ -2230,6 +2235,7 @@ export default (options = {}) => {
 			if (node.readonly) context.write('readonly ');
 			context.write('[');
 
+			track_bindings(node.parameters);
 			// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
 			sequence(context, node.parameters, node.typeAnnotation?.loc?.start ?? null, false);
 			context.write(']');
@@ -2302,7 +2308,7 @@ export default (options = {}) => {
 			}
 
 			// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
-			track_param_bindings(node.parameters ?? node.params);
+			track_bindings(node.parameters ?? node.params);
 			context.write('(');
 			sequence(
 				context,

--- a/test/comment-jsdoc-type-cast-bindings.test.js
+++ b/test/comment-jsdoc-type-cast-bindings.test.js
@@ -47,3 +47,32 @@ test('JSDoc @type comment on a parameter with a default value is not wrapped', (
 	// output must be valid JavaScript
 	expect(() => new Function(code)).not.toThrow();
 });
+
+test.each([
+	['a rest parameter', 'function f(.../** @type {any} */ rest) {}', 'js'],
+	[
+		'a nested parameter pattern',
+		'function f({ key: [/** @type {any} */ value] = [] } = {}) {}',
+		'js'
+	],
+	[
+		'a TypeScript parameter property',
+		'class C { constructor(public /** @type {any} */ value) {} }',
+		'ts'
+	],
+	['a declared function identifier', 'declare function /** @type {any} */ f(): void;', 'ts'],
+	[
+		'an index signature parameter',
+		'interface X { [/** @type {any} */ key: string]: unknown }',
+		'ts'
+	],
+	['a destructured variable', 'let [/** @type {any} */ value] = values;', 'js'],
+	['a destructured catch parameter', 'try {} catch ({ key: /** @type {any} */ value }) {}', 'js']
+])('JSDoc @type comment on %s is not wrapped', (_, input, fileExtension) => {
+	const { ast, comments } = acornParse(input, { fileExtension });
+	const { code } = print(ast, ts({ comments }), {});
+
+	expect(code).toContain('/** @type {any} */');
+	expect(code).not.toContain('*/ (');
+	expect(() => acornParse(code, { fileExtension })).not.toThrow();
+});

--- a/test/comment-jsdoc-type-cast-bindings.test.js
+++ b/test/comment-jsdoc-type-cast-bindings.test.js
@@ -1,0 +1,49 @@
+// @ts-check
+/** @import { TSESTree } from '@typescript-eslint/types' */
+import { expect, test } from 'vitest';
+import { print } from '../src/index.js';
+import { acornParse } from './common.js';
+import ts from '../src/languages/ts/index.js';
+
+// Regression test for https://github.com/sveltejs/esrap/issues/181:
+// a JSDoc `@type` comment re-anchored to a binding position (function parameter
+// with a default value) must not be treated as a type cast — wrapping the
+// binding target in parentheses produces invalid JS (`(row) = $.noop`).
+test('JSDoc @type comment on a parameter with a default value is not wrapped', () => {
+	const input = `const row_template = ($$anchor, row = $.noop) => {
+	row;
+};`;
+
+	const { ast } = acornParse(input);
+	const arrow = /** @type {TSESTree.ArrowFunctionExpression} */ (
+		/** @type {any} */ (ast.body[0]).declarations[0].init
+	);
+	const param = /** @type {TSESTree.AssignmentPattern} */ (arrow.params[1]);
+
+	// svelte re-anchors template comments onto freshly generated AST nodes whose
+	// synthetic `loc` starts before the binding identifier itself
+	/** @type {any} */ (param).start = /** @type {any} */ (param.left).start - 4;
+	param.loc = {
+		start: { line: 1, column: /** @type {any} */ (param.left).start - 4 },
+		end: /** @type {any} */ (param.loc).end
+	};
+
+	const anchor = /** @type {any} */ (param.left).start - 3;
+	const comments = [
+		{
+			type: /** @type {const} */ ('Block'),
+			value: '* @type {any} ',
+			start: anchor,
+			end: anchor,
+			loc: { start: { line: 1, column: anchor }, end: { line: 1, column: anchor } }
+		}
+	];
+
+	const { code } = print(ast, ts({ comments }), {});
+
+	expect(code).toContain('/** @type {any} */ row = $.noop');
+	expect(code).not.toContain('(row)');
+
+	// output must be valid JavaScript
+	expect(() => new Function(code)).not.toThrow();
+});

--- a/test/esrap.test.js
+++ b/test/esrap.test.js
@@ -128,6 +128,21 @@ test('should have 1 baseline', () => {
 	expect(numberOfBaseLine).toBe(1);
 });
 
+test('preserves JSDoc type casts from Acorn parenthesized expressions', () => {
+	const source = `const foo = /** @type {number} */ (1);
+const bar = /** @type {number} */ (/** @type {number} */ (1));`;
+	const { ast, comments } = acornParse(source, {
+		sourceType: 'module',
+		jsxMode: false,
+		fileExtension: 'js',
+		preserveParens: true
+	});
+	const type_cast = /** @type {any} */ (ast.body[0]).declarations[0].init;
+
+	expect(type_cast.type).toBe('ParenthesizedExpression');
+	expect(print(ast, tsx({ comments })).code).toBe(source);
+});
+
 for (const dir of fs.readdirSync(`${__dirname}/samples`)) {
 	if (dir.includes('large-file')) continue;
 

--- a/test/samples/comment-jsdoc-type-cast-param-default/expected.js
+++ b/test/samples/comment-jsdoc-type-cast-param-default/expected.js
@@ -1,0 +1,11 @@
+const row_template = ($$anchor, row = $.noop) => {
+	row;
+};
+
+const f = ({ a } = {}) => a;
+
+function g(x = 1) {
+	return x;
+}
+
+const value = /** @type {number} */ (computed);

--- a/test/samples/comment-jsdoc-type-cast-param-default/expected.js.map
+++ b/test/samples/comment-jsdoc-type-cast-param-default/expected.js.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": [
+    "input.js"
+  ],
+  "sourcesContent": [
+    "const row_template = ($$anchor, row = $.noop) => {\n\trow;\n};\n\nconst f = ({ a } = {}) => a;\n\nfunction g(x = 1) {\n\treturn x;\n}\n\nconst value = /** @type {number} */ (computed);\n"
+  ],
+  "mappings": "AAAA,MAAM,AAAA,YAAY,IAAI,QAAQ,EAAE,GAAG,GAAG,CAAC,CAAC,IAAI,KAAK,CAAC;CACjD,GAAG;AACJ,CAAC;;AAED,MAAM,AAAA,CAAC,MAAM,CAAC,YAAY,CAAC;;AAE3B,QAAQ,CAAC,CAAC,CAAC,CAAC,GAAG,CAAC,EAAE,CAAC;CAClB,MAAM,CAAC,CAAC;AACT,CAAC;;AAED,MAAM,AAAA,KAAK,0BAA0B,QAAQ"
+}

--- a/test/samples/comment-jsdoc-type-cast-param-default/input.js
+++ b/test/samples/comment-jsdoc-type-cast-param-default/input.js
@@ -1,0 +1,11 @@
+const row_template = ($$anchor, row = $.noop) => {
+	row;
+};
+
+const f = ({ a } = {}) => a;
+
+function g(x = 1) {
+	return x;
+}
+
+const value = /** @type {number} */ (computed);


### PR DESCRIPTION
Fixes #181.

The binding-position tracking introduced in #167 marks the parameter nodes themselves, but a parameter with a default value is an `AssignmentPattern` — the binding is its `left` identifier, which was never marked. A `/** @type {…} */` comment re-anchored there (svelte re-anchors template comments onto freshly generated nodes with synthetic locs) is still treated as a cast and the binding target gets wrapped, producing output that fails to parse:

```js
const row_template = ($$anchor, /** @type {any} */ (row) = $.noop) => {
``
A named function's `id` has the same gap: the flush can wrap it into `function /** @type {any} */ (h)(…)`.

This marks `AssignmentPattern.left` alongside its parent pattern (via a `track_param_bindings` helper used at every param-tracking call site) and tracks `FunctionDeclaration`/`FunctionExpression` ids as binding positions.

New regression test: `test/comment-jsdoc-type-cast-bindings.test.js` (asserts the output stays valid JS), plus a sample under `test/samples/comment-jsdoc-type-cast-param-default/`. All 297 tests pass, `pnpm check` and `pnpm lint` are clean.