### PR TITLE
feat: locate internal delimiters exactly from parser tokens in boundaryTokens maps

### DIFF
--- a/.changeset/exact-boundary-token-locations.md
+++ b/.changeset/exact-boundary-token-locations.md
@@ -1,0 +1,5 @@
+---
+'esrap': minor
+---
+
+Locate delimiters internal to AST nodes exactly in `boundaryTokens` source maps. Pass the parser's `tokens` and the brackets of computed keys, the parentheses of calls, functions and control-flow statements, and the braces of import/export lists, enums, static blocks and template interpolations are anchored to their real source positions. Computed-key brackets are no longer guessed from the key's position; without `tokens` they are left unmapped.

--- a/src/languages/ts/boundary-tokens.js
+++ b/src/languages/ts/boundary-tokens.js
@@ -1,0 +1,194 @@
+/** @import { TSESTree } from '@typescript-eslint/types' */
+/** @import { SourceToken, TSOptions } from '../types.js' */
+
+/** @typedef {{ line: number, column: number }} Position */
+/** @typedef {{ start: Position, end: Position }} Location */
+
+/** The delimiters that can be located from a parser's token stream */
+const DELIMITERS = new Set(['(', ')', '[', ']', '{', '}', '${']);
+
+/**
+ * Orders two positions: negative when `a` comes first, positive when `b` does
+ * @param {Position} a
+ * @param {Position} b
+ */
+export function compare_positions(a, b) {
+	return a.line - b.line || a.column - b.column;
+}
+
+/**
+ * The punctuator a parser token stands for. Acorn and Babel put it on
+ * `type.label`; ESLint-style tokens (espree, typescript-eslint) use
+ * `type: 'Punctuator'` with the punctuator in `value`.
+ * @param {SourceToken} token
+ */
+function punctuator(token) {
+	const { type } = token;
+	if (typeof type === 'object') return type.label;
+	if (type === 'Punctuator') return token.value;
+	return type;
+}
+
+/**
+ * Synthetic one-token nodes that give structural tokens (`(`, `[`, `{`, unary
+ * operators, …) sourcemap anchors. Without them, everything up to the next
+ * mapped token is attributed to the previous token's source position, because
+ * `write(content, node)` only maps content written with a node. Opt-in via
+ * `boundaryTokens`: denser maps, byte-identical output.
+ *
+ * Tokens at a node's own boundary are derived from its `loc`. Tokens internal
+ * to a node (the brackets around a computed key, the parentheses of a call or
+ * an `if`) are looked up in the parser's token stream when `tokens` is
+ * supplied, and are otherwise left unmapped rather than guessed.
+ *
+ * @param {TSOptions} options
+ */
+export function boundary_tokens(options) {
+	let instance = instances.get(options);
+	if (!instance) {
+		instance = create_boundary_tokens(options);
+		instances.set(options, instance);
+	}
+	return instance;
+}
+
+/** One instance per options object, so `tsx` shares the delimiter index built for `ts` */
+/** @type {WeakMap<TSOptions, ReturnType<typeof create_boundary_tokens>>} */
+const instances = new WeakMap();
+
+/** @param {TSOptions} options */
+function create_boundary_tokens(options) {
+	const enabled = options.boundaryTokens === true;
+
+	/**
+	 * The delimiter tokens from `options.tokens`, in source order
+	 * @type {{ value: string, loc: Location }[] | undefined}
+	 */
+	let delimiters;
+
+	function get_delimiters() {
+		if (delimiters === undefined) {
+			delimiters = [];
+			let sorted = true;
+
+			for (const token of options.tokens ?? []) {
+				const value = punctuator(token);
+				if (typeof value !== 'string' || !DELIMITERS.has(value) || !token.loc) continue;
+
+				const previous = delimiters[delimiters.length - 1];
+				if (previous && compare_positions(previous.loc.start, token.loc.start) > 0) sorted = false;
+				delimiters.push({ value, loc: token.loc });
+			}
+
+			// a backtracking parser can re-emit tokens; the binary search needs monotone positions
+			if (!sorted) {
+				delimiters.sort((a, b) => compare_positions(a.loc.start, b.loc.start));
+			}
+		}
+
+		return delimiters;
+	}
+
+	/**
+	 * The nearest `value` delimiter on `side` of `pos`, without leaving `node`
+	 * @param {TSESTree.Node} node
+	 * @param {string} value
+	 * @param {Position} pos
+	 * @param {'before' | 'after'} side
+	 */
+	function find(node, value, pos, side) {
+		if (!node.loc) return undefined;
+
+		const tokens = get_delimiters();
+		let lo = 0;
+		let hi = tokens.length - 1;
+
+		if (side === 'before') {
+			// rightmost token ending at or before `pos`
+			while (lo <= hi) {
+				const mid = (lo + hi) >> 1;
+				if (compare_positions(tokens[mid].loc.end, pos) > 0) hi = mid - 1;
+				else lo = mid + 1;
+			}
+
+			for (let i = hi; i >= 0; i -= 1) {
+				const token = tokens[i];
+				if (compare_positions(token.loc.start, node.loc.start) < 0) break;
+				if (token.value === value) return token.loc;
+			}
+		} else {
+			// leftmost token starting at or after `pos`
+			while (lo <= hi) {
+				const mid = (lo + hi) >> 1;
+				if (compare_positions(tokens[mid].loc.start, pos) < 0) lo = mid + 1;
+				else hi = mid - 1;
+			}
+
+			for (let i = lo; i < tokens.length; i += 1) {
+				const token = tokens[i];
+				if (compare_positions(token.loc.end, node.loc.end) > 0) break;
+				if (token.value === value) return token.loc;
+			}
+		}
+	}
+
+	/** @param {Location | undefined} loc */
+	function token_node(loc) {
+		if (!enabled || !loc) return undefined;
+		return /** @type {any} */ ({ loc });
+	}
+
+	/**
+	 * A token of `length` characters starting at `pos`
+	 * @param {Position | undefined} pos
+	 * @param {number} [length]
+	 */
+	function token_at(pos, length = 1) {
+		return token_node(pos && { start: pos, end: { line: pos.line, column: pos.column + length } });
+	}
+
+	/**
+	 * A one-character token ending at `pos`
+	 * @param {Position | undefined} pos
+	 */
+	function token_before(pos) {
+		return token_node(
+			pos && pos.column > 0
+				? { start: { line: pos.line, column: pos.column - 1 }, end: pos }
+				: undefined
+		);
+	}
+
+	/**
+	 * The `value` delimiter nearest to `pos` on `side`, located from the
+	 * parser's tokens. `undefined` when it cannot be located — because `tokens`
+	 * were not supplied, or because the delimiter does not exist in the source.
+	 * @param {TSESTree.Node} node
+	 * @param {string} value
+	 * @param {Position | undefined} pos
+	 * @param {'before' | 'after'} side
+	 */
+	function located_token(node, value, pos, side) {
+		if (!enabled || !pos) return undefined;
+		return token_node(find(node, value, pos, side));
+	}
+
+	/**
+	 * The delimiter that opens (just before `inner`) or closes (just after
+	 * `inner`) a bracketed part of `node`.
+	 * @param {TSESTree.Node} node
+	 * @param {TSESTree.Node | null | undefined} inner
+	 * @param {'(' | ')' | '[' | ']' | '{' | '}' | '${'} value
+	 */
+	function enclosing_token(node, inner, value) {
+		const opening = value !== ')' && value !== ']' && value !== '}';
+		return located_token(
+			node,
+			value,
+			opening ? inner?.loc?.start : inner?.loc?.end,
+			opening ? 'before' : 'after'
+		);
+	}
+
+	return { token_at, token_before, located_token, enclosing_token };
+}

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -2,6 +2,7 @@
 /** @import { Visitors } from '../../types.js' */
 /** @import { TSOptions, BaseComment } from '../types.js' */
 import { Context } from 'esrap';
+import { boundary_tokens, compare_positions } from './boundary-tokens.js';
 
 /** @typedef {TSESTree.Node} Node */
 
@@ -340,7 +341,7 @@ export default (options = {}) => {
 	/**
 	 * @param {Context} context
 	 * @param {{ line: number, column: number } | null} from
-	 * @param {{ line: number, column: number }} to
+	 * @param {{ line: number, column: number } | null} to
 	 * @param {boolean} pad
 	 * @param {boolean} [is_next_to_expression]
 	 */
@@ -402,13 +403,15 @@ export default (options = {}) => {
 
 	/**
 	 * @param {Context} context
-	 * @param {{ attributes?: TSESTree.ImportAttribute[], assertions?: TSESTree.ImportAttribute[] }} node
+	 * @param {TSESTree.Node & { attributes?: TSESTree.ImportAttribute[], assertions?: TSESTree.ImportAttribute[] }} node
 	 */
 	function write_import_attributes(context, node) {
 		const attributes = node.attributes ?? node.assertions;
 		if (!attributes || attributes.length === 0) return;
 
-		context.write(node.attributes ? ' with { ' : ' assert { ');
+		context.write(node.attributes ? ' with ' : ' assert ');
+		context.write('{', located_token(node, '{', attributes[0].loc?.start, 'before'));
+		context.write(' ');
 
 		for (let i = 0; i < attributes.length; i += 1) {
 			const { key, value } = attributes[i];
@@ -418,13 +421,17 @@ export default (options = {}) => {
 			if (i < attributes.length - 1) context.write(', ');
 		}
 
-		context.write(' }');
+		context.write(' ');
+		context.write(
+			'}',
+			located_token(node, '}', attributes[attributes.length - 1].loc?.end, 'after')
+		);
 	}
 
 	/**
 	 * @param {Context} context
 	 * @param {TSESTree.Node[]} nodes
-	 * @param {{ line: number, column: number }} until
+	 * @param {{ line: number, column: number } | null} until
 	 * @param {boolean} pad
 	 */
 	function sequence(context, nodes, until, pad, separator = ',', trailing_newline = true) {
@@ -550,34 +557,70 @@ export default (options = {}) => {
 		}
 	}
 
-	const boundary_tokens = options.boundaryTokens === true;
+	const { token_at, token_before, located_token, enclosing_token } = boundary_tokens(options);
 
 	/**
-	 * A one-character synthetic token node so structural tokens (`(`, `[`, `{`,
-	 * unary operators, …) written where a node's SOURCE span begins or ends get a
-	 * sourcemap anchor. Without it, everything up to the next mapped token is
-	 * attributed to the PREVIOUS token's source position — `write(content, node)`
-	 * only maps tokens written with a node, and these boundary characters belong
-	 * to no written token. Opt-in (`boundaryTokens`): denser maps, byte-identical
-	 * output.
-	 * @param {{ line: number, column: number } | undefined} pos
-	 * @param {number} [length]
+	 * A parenthesised parameter list. `(` is anchored to the first one after
+	 * `prefix` (the type parameters, name or key before the list) or, without
+	 * one, to the last `(` before the first parameter; `)` to the last one
+	 * before `suffix` (the return type or body after the list).
+	 * @param {Context} context
+	 * @param {TSESTree.Node} node
+	 * @param {TSESTree.Node[]} params
+	 * @param {TSESTree.Node | null | undefined} prefix
+	 * @param {TSESTree.Node | null | undefined} suffix
+	 * @param {{ line: number, column: number } | null} [until] where trailing comments of the list stop
 	 */
-	function token_at(pos, length = 1) {
-		if (!boundary_tokens) return undefined;
-		if (!pos) return undefined;
-		return /** @type {any} */ ({
-			loc: { start: pos, end: { line: pos.line, column: pos.column + length } }
-		});
+	function write_params(
+		context,
+		node,
+		params,
+		prefix,
+		suffix,
+		until = suffix?.loc?.start ?? node.loc?.end ?? null
+	) {
+		const open = prefix?.loc
+			? located_token(node, '(', prefix.loc.end, 'after')
+			: params[0]?.loc
+				? located_token(node, '(', params[0].loc.start, 'before')
+				: located_token(node, '(', node.loc?.start, 'after');
+
+		context.write('(', open);
+		sequence(context, params, until, false);
+		context.write(')', located_token(node, ')', suffix?.loc?.start ?? node.loc?.end, 'before'));
 	}
 
-	/** @param {{ line: number, column: number } | undefined} pos */
-	function token_before(pos) {
-		if (!boundary_tokens) return undefined;
-		if (!pos || pos.column === 0) return undefined;
-		return /** @type {any} */ ({
-			loc: { start: { line: pos.line, column: pos.column - 1 }, end: pos }
-		});
+	/**
+	 * The first `(` in `node`, for `keyword (…)` forms
+	 * @param {TSESTree.Node} node
+	 */
+	function opening_paren(node) {
+		return located_token(node, '(', node.loc?.start, 'after');
+	}
+
+	/**
+	 * `keyword (`, with the keyword mapped and the parenthesis anchored
+	 * @param {Context} context
+	 * @param {TSESTree.Node} node
+	 * @param {string} keyword
+	 * @param {string} [suffix=' '] between the keyword and the parenthesis
+	 */
+	function write_keyword_paren(context, node, keyword, suffix = ' ') {
+		write_keyword(context, node, keyword, suffix);
+		context.write('(', opening_paren(node));
+	}
+
+	/**
+	 * Parentheses the author wrote, anchored to their source positions
+	 * @param {Context} context
+	 * @param {TSESTree.Node} node
+	 * @param {TSESTree.Node} inner
+	 */
+	function write_parenthesized(context, node, inner) {
+		if (!node.loc) return maybe_wrap(context, inner, true);
+		context.write('(', token_at(node.loc.start));
+		context.visit(inner);
+		context.write(')', token_before(node.loc.end));
 	}
 
 	const shared = {
@@ -671,11 +714,12 @@ export default (options = {}) => {
 			}
 
 			if (node.typeArguments) context.visit(node.typeArguments);
+			const call_prefix = node.typeArguments ?? node.callee;
 
 			const open = context.new();
 			const join = context.new();
 
-			context.write('(');
+			context.write('(', located_token(node, '(', call_prefix.loc?.end, 'after'));
 			context.append(open);
 
 			// if the final argument is multiline, it doesn't need to force all the
@@ -800,7 +844,7 @@ export default (options = {}) => {
 				else context.write('await ');
 			}
 
-			context.write('(');
+			context.write('(', opening_paren(node));
 
 			if (node.left.type === 'VariableDeclaration') {
 				handle_var_declaration(node.left, context);
@@ -810,7 +854,8 @@ export default (options = {}) => {
 
 			context.write(node.type === 'ForInStatement' ? ' in ' : ' of ');
 			context.visit(node.right);
-			context.write(') ');
+			context.write(')', located_token(node, ')', node.body.loc?.start, 'before'));
+			context.write(' ');
 			context.visit(node.body);
 		},
 
@@ -851,9 +896,13 @@ export default (options = {}) => {
 			}
 
 			track_bindings(node.params);
-			context.write('(');
-			sequence(context, node.params, (node.returnType ?? node.body).loc?.start ?? null, false);
-			context.write(')');
+			write_params(
+				context,
+				node,
+				node.params,
+				node.typeParameters ?? node.id,
+				node.returnType ?? node.body
+			);
 
 			if (node.returnType) context.visit(node.returnType);
 
@@ -902,25 +951,27 @@ export default (options = {}) => {
 
 			if (node.value.generator) context.write('*');
 
-			if (node.computed) context.write('[', token_before(node.key.loc?.start));
+			if (node.computed) context.write('[', enclosing_token(node, node.key, '['));
 			context.visit(node.key);
-			if (node.computed) context.write(']', token_at(node.key.loc?.end));
+			if (node.computed) context.write(']', enclosing_token(node, node.key, ']'));
 
 			// optional method (`m?()`)
 			if (node.optional) context.write('?');
 
-			// @ts-expect-error `typeParameters` lives on the method node, not its value
-			if (node.typeParameters) context.visit(node.typeParameters);
+			// `typeParameters` lives on the method node, not its value
+			const method_type_parameters =
+				/** @type {{ typeParameters?: TSESTree.TSTypeParameterDeclaration }} */ (node)
+					.typeParameters;
+			if (method_type_parameters) context.visit(method_type_parameters);
 
 			track_bindings(node.value.params);
-			context.write('(');
-			sequence(
+			write_params(
 				context,
+				node,
 				node.value.params,
-				(node.value.returnType ?? node.value.body)?.loc?.start ?? node.loc?.end ?? null,
-				false
+				method_type_parameters ?? node.key,
+				node.value.returnType ?? node.value.body
 			);
-			context.write(')');
 
 			if (node.value.returnType) context.visit(node.value.returnType);
 
@@ -978,9 +1029,9 @@ export default (options = {}) => {
 			}
 
 			if (node.computed) {
-				context.write('[', token_before(node.key.loc?.start));
+				context.write('[', enclosing_token(node, node.key, '['));
 				context.visit(node.key);
-				context.write(']', token_at(node.key.loc?.end));
+				context.write(']', enclosing_token(node, node.key, ']'));
 			} else {
 				context.visit(node.key);
 			}
@@ -1035,24 +1086,19 @@ export default (options = {}) => {
 				context.visit(node.typeParameters);
 			}
 
-			// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
-			track_bindings(node.parameters ?? node.params);
-			context.write('(');
-			sequence(
+			const parameters = signature_parameters(node);
+			const return_type = signature_return_type(node);
+			track_bindings(parameters);
+			write_params(
 				context,
-				// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
-				node.parameters ?? node.params,
-				// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
-				(node.typeAnnotation ?? node.returnType)?.loc?.start ?? null,
-				false
+				node,
+				parameters,
+				node.typeParameters,
+				return_type,
+				return_type?.loc?.start ?? null
 			);
-			context.write(')');
 
-			// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
-			if (node.typeAnnotation || node.returnType) {
-				// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
-				context.visit(node.typeAnnotation ?? node.returnType);
-			}
+			if (return_type) context.visit(return_type);
 		},
 
 		/**
@@ -1066,25 +1112,21 @@ export default (options = {}) => {
 			}
 			if (node.typeParameters) context.visit(node.typeParameters);
 
-			// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
-			track_bindings(node.parameters ?? node.params);
-			context.write('(');
-			sequence(
+			const parameters = signature_parameters(node);
+			const return_type = signature_return_type(node);
+			track_bindings(parameters);
+			write_params(
 				context,
-				// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
-				node.parameters ?? node.params,
-				// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
-				node.typeAnnotation?.typeAnnotation?.loc?.start ??
-					node.returnType?.typeAnnotation?.loc?.start ??
-					null,
-				false
+				node,
+				parameters,
+				node.typeParameters,
+				return_type,
+				return_type?.typeAnnotation?.loc?.start ?? null
 			);
-			context.write(')');
 
 			context.write(' => ');
 
-			// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
-			context.visit(node.typeAnnotation?.typeAnnotation ?? node.returnType?.typeAnnotation);
+			context.visit(/** @type {TSESTree.Node} */ (return_type?.typeAnnotation));
 		}
 	};
 
@@ -1140,9 +1182,7 @@ export default (options = {}) => {
 			}
 
 			track_bindings(node.params);
-			context.write('(');
-			sequence(context, node.params, (node.returnType ?? node.body).loc?.start ?? null, false);
-			context.write(')');
+			write_params(context, node, node.params, node.typeParameters, node.returnType ?? node.body);
 
 			if (node.returnType) context.visit(node.returnType);
 
@@ -1277,13 +1317,15 @@ export default (options = {}) => {
 			if (test_loc && body_end && body_end.line === test_loc.line && test_loc.column >= 6) {
 				context.write(' ');
 				write_source_keyword(context, body_end.line, body_end.column + 1, 'while');
-				context.write(' (');
+				context.write(' ');
 			} else {
-				context.write(' while (');
+				context.write(' while ');
 			}
 
+			context.write('(', located_token(node, '(', node.body.loc?.end, 'after'));
 			context.visit(node.test);
-			context.write(');');
+			context.write(')', located_token(node, ')', node.loc?.end, 'before'));
+			context.write(';');
 		},
 
 		EmptyStatement(node, context) {
@@ -1345,9 +1387,12 @@ export default (options = {}) => {
 				else context.write('type ');
 			}
 
-			context.write('{');
+			context.write('{', located_token(node, '{', node.loc?.start, 'after'));
 			sequence(context, node.specifiers, node.source?.loc?.start ?? node.loc?.end ?? null, true);
-			context.write('}');
+			context.write(
+				'}',
+				located_token(node, '}', node.source?.loc?.start ?? node.loc?.end, 'before')
+			);
 
 			if (node.source) {
 				context.write(' from ');
@@ -1379,7 +1424,7 @@ export default (options = {}) => {
 		},
 
 		ForStatement: (node, context) => {
-			write_keyword(context, node, 'for', ' (');
+			write_keyword_paren(context, node, 'for');
 
 			if (node.init) {
 				if (node.init.type === 'VariableDeclaration') {
@@ -1394,7 +1439,8 @@ export default (options = {}) => {
 			context.write('; ');
 			if (node.update) context.visit(node.update);
 
-			context.write(') ');
+			context.write(')', located_token(node, ')', node.body.loc?.start, 'before'));
+			context.write(' ');
 			context.visit(node.body);
 		},
 
@@ -1419,9 +1465,10 @@ export default (options = {}) => {
 		},
 
 		IfStatement(node, context) {
-			write_keyword(context, node, 'if', ' (');
+			write_keyword_paren(context, node, 'if');
 			context.visit(node.test);
-			context.write(') ');
+			context.write(')', located_token(node, ')', node.consequent.loc?.start, 'before'));
+			context.write(' ');
 
 			if (node.alternate && statement_ends_with_unmatched_if(node.consequent)) {
 				context.write('{');
@@ -1497,9 +1544,9 @@ export default (options = {}) => {
 			}
 
 			if (named_specifiers.length > 0) {
-				context.write('{');
+				context.write('{', located_token(node, '{', node.loc?.start, 'after'));
 				sequence(context, named_specifiers, node.source.loc?.start ?? null, true);
-				context.write('}');
+				context.write('}', located_token(node, '}', node.source.loc?.start, 'before'));
 			}
 
 			context.write(' from ');
@@ -1509,7 +1556,7 @@ export default (options = {}) => {
 		},
 
 		ImportExpression(node, context) {
-			write_keyword(context, node, 'import', '(');
+			write_keyword_paren(context, node, 'import', '');
 			context.visit(node.source);
 			//@ts-expect-error for some reason the types haven't been updated
 			if (node.arguments) {
@@ -1524,7 +1571,7 @@ export default (options = {}) => {
 				context.write(', ');
 				context.visit(node.options);
 			}
-			context.write(')');
+			context.write(')', token_before(node.loc?.end));
 		},
 
 		ImportSpecifier(node, context) {
@@ -1575,7 +1622,7 @@ export default (options = {}) => {
 				if (node.optional) {
 					context.write('?.');
 				}
-				context.write('[');
+				context.write('[', enclosing_token(node, node.property, '['));
 				context.visit(node.property);
 				context.write(']', token_before(node.loc?.end));
 			} else {
@@ -1610,13 +1657,7 @@ export default (options = {}) => {
 
 		// @ts-expect-error this isn't a real node type, but Acorn produces it
 		ParenthesizedExpression(node, context) {
-			if (node.loc) {
-				context.write('(', token_at(node.loc.start));
-				context.visit(node.expression);
-				context.write(')', token_before(node.loc.end));
-			} else {
-				maybe_wrap(context, node.expression, true);
-			}
+			write_parenthesized(context, node, node.expression);
 		},
 
 		PrivateIdentifier(node, context) {
@@ -1653,31 +1694,30 @@ export default (options = {}) => {
 				if (node.kind !== 'init') kw(node.kind + ' ');
 				if (node.value.async) kw('async ');
 				if (node.value.generator) context.write('*');
-				if (node.computed) context.write('[', token_before(node.key.loc?.start));
+				if (node.computed) context.write('[', enclosing_token(node, node.key, '['));
 				context.visit(node.key);
-				if (node.computed) context.write(']', token_at(node.key.loc?.end));
+				if (node.computed) context.write(']', enclosing_token(node, node.key, ']'));
 				track_bindings(node.value.params);
-				context.write('(');
-				sequence(
+				write_params(
 					context,
+					node,
 					node.value.params,
-					(node.value.returnType ?? node.value.body).loc?.start ?? null,
-					false
+					node.value.typeParameters ?? node.key,
+					node.value.returnType ?? node.value.body
 				);
-				context.write(')');
 
 				if (node.value.returnType) context.visit(node.value.returnType);
 
 				context.write(' ');
 				context.visit(node.value.body);
 			} else {
-				if (node.computed) context.write('[', token_before(node.key.loc?.start));
+				if (node.computed) context.write('[', enclosing_token(node, node.key, '['));
 				if (node.kind === 'get' || node.kind === 'set') {
 					write_keyword(context, node, node.kind, ' ');
 				}
 				context.visit(node.key);
 				if (node.computed) {
-					context.write(']', token_at(node.key.loc?.end));
+					context.write(']', enclosing_token(node, node.key, ']'));
 					context.write(': ');
 				} else {
 					context.write(': ');
@@ -1718,7 +1758,8 @@ export default (options = {}) => {
 		SpreadElement: shared['RestElement|SpreadElement'],
 
 		StaticBlock(node, context) {
-			write_keyword(context, node, 'static', ' {');
+			write_keyword(context, node, 'static', ' ');
+			context.write('{', located_token(node, '{', node.loc?.start, 'after'));
 			context.indent();
 			context.newline();
 
@@ -1726,7 +1767,7 @@ export default (options = {}) => {
 
 			context.dedent();
 			context.newline();
-			context.write('}');
+			context.write('}', token_before(node.loc?.end));
 		},
 
 		Super(node, context) {
@@ -1734,9 +1775,14 @@ export default (options = {}) => {
 		},
 
 		SwitchStatement(node, context) {
-			write_keyword(context, node, 'switch', ' (');
+			write_keyword_paren(context, node, 'switch');
 			context.visit(node.discriminant);
-			context.write(') {');
+			context.write(
+				')',
+				located_token(node, ')', node.cases[0]?.loc?.start ?? node.loc?.end, 'before')
+			);
+			context.write(' ');
+			context.write('{', located_token(node, '{', node.discriminant.loc?.end, 'after'));
 			context.indent();
 
 			let first = true;
@@ -1770,7 +1816,7 @@ export default (options = {}) => {
 
 			context.dedent();
 			context.newline();
-			context.write('}');
+			context.write('}', token_before(node.loc?.end));
 		},
 
 		TaggedTemplateExpression(node, context) {
@@ -1792,9 +1838,10 @@ export default (options = {}) => {
 			for (let i = 0; i < expressions.length; i++) {
 				const raw = quasis[i].value.raw;
 
-				context.write(raw + '${');
+				context.write(raw);
+				context.write('${', enclosing_token(node, expressions[i], '${'));
 				context.visit(expressions[i]);
-				context.write('}');
+				context.write('}', enclosing_token(node, expressions[i], '}'));
 
 				if (/\n/.test(raw)) context.multiline = true;
 			}
@@ -1823,10 +1870,14 @@ export default (options = {}) => {
 				context.write(' ');
 
 				if (node.handler.param) {
-					write_keyword(context, node.handler, 'catch', '(');
+					write_keyword_paren(context, node.handler, 'catch', '');
 					track_binding(node.handler.param);
 					context.visit(node.handler.param);
-					context.write(') ');
+					context.write(
+						')',
+						located_token(node.handler, ')', node.handler.body.loc?.start, 'before')
+					);
+					context.write(' ');
 				} else {
 					write_keyword(context, node.handler, 'catch', ' ');
 				}
@@ -1889,16 +1940,18 @@ export default (options = {}) => {
 		},
 
 		WhileStatement(node, context) {
-			write_keyword(context, node, 'while', ' (');
+			write_keyword_paren(context, node, 'while');
 			context.visit(node.test);
-			context.write(') ');
+			context.write(')', located_token(node, ')', node.body.loc?.start, 'before'));
+			context.write(' ');
 			context.visit(node.body);
 		},
 
 		WithStatement(node, context) {
-			write_keyword(context, node, 'with', ' (');
+			write_keyword_paren(context, node, 'with');
 			context.visit(node.object);
-			context.write(') ');
+			context.write(')', located_token(node, ')', node.body.loc?.start, 'before'));
+			context.write(' ');
 			context.visit(node.body);
 		},
 
@@ -1952,13 +2005,9 @@ export default (options = {}) => {
 			}
 
 			track_bindings(node.params);
-			context.write('(');
-			sequence(context, node.params, node.returnType?.loc?.start ?? node.loc?.end ?? null, false);
-			context.write(')');
+			write_params(context, node, node.params, node.typeParameters ?? node.id, node.returnType);
 
-			if (node.returnType) {
-				context.visit(node.returnType);
-			}
+			if (node.returnType) context.visit(node.returnType);
 
 			context.write(';');
 		},
@@ -2017,7 +2066,9 @@ export default (options = {}) => {
 
 		TSArrayType(node, context) {
 			context.visit(node.elementType);
-			context.write('[]');
+			const element_end = node.elementType.loc?.end;
+			context.write('[', located_token(node, '[', element_end, 'after'));
+			context.write(']', token_before(node.loc?.end));
 		},
 
 		TSTypeAnnotation(node, context) {
@@ -2026,16 +2077,18 @@ export default (options = {}) => {
 		},
 
 		TSTypeLiteral(node, context) {
-			context.write('{ ');
+			context.write('{', token_at(node.loc?.start));
+			context.write(' ');
 			sequence(context, node.members, node.loc?.end ?? null, false, ';');
-			context.write(' }');
+			context.write(' ');
+			context.write('}', token_before(node.loc?.end));
 		},
 
 		TSPropertySignature(node, context) {
 			if (node.readonly) context.write('readonly ');
-			if (node.computed) context.write('[', token_before(node.key.loc?.start));
+			if (node.computed) context.write('[', enclosing_token(node, node.key, '['));
 			context.visit(node.key);
-			if (node.computed) context.write(']', token_at(node.key.loc?.end));
+			if (node.computed) context.write(']', enclosing_token(node, node.key, ']'));
 			if (node.optional) context.write('?');
 			if (node.typeAnnotation) context.visit(node.typeAnnotation);
 		},
@@ -2061,9 +2114,10 @@ export default (options = {}) => {
 			for (let i = 0; i < types.length; i++) {
 				const raw = quasis[i].value.raw;
 
-				context.write(raw + '${');
+				context.write(raw);
+				context.write('${', enclosing_token(node, types[i], '${'));
 				context.visit(types[i]);
-				context.write('}');
+				context.write('}', enclosing_token(node, types[i], '}'));
 
 				if (/\n/.test(raw)) context.multiline = true;
 			}
@@ -2205,18 +2259,24 @@ export default (options = {}) => {
 
 		TSIndexSignature(node, context) {
 			if (node.readonly) context.write('readonly ');
-			context.write('[');
+			const first_parameter = node.parameters[0];
+			const last_parameter = node.parameters[node.parameters.length - 1];
+			context.write('[', enclosing_token(node, first_parameter, '['));
 
-			// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
 			sequence(context, node.parameters, node.typeAnnotation?.loc?.start ?? null, false);
-			context.write(']');
+			context.write(']', enclosing_token(node, last_parameter, ']'));
 
 			// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
 			context.visit(node.typeAnnotation);
 		},
 
 		TSMappedType(node, context) {
-			context.write('{');
+			context.write('{', token_at(node.loc?.start));
+			const legacy_type_parameter = node.typeParameter;
+			const key = node.key ?? legacy_type_parameter?.name;
+			const constraint = node.constraint ?? legacy_type_parameter?.constraint;
+			const first_bracket_child = key && typeof key === 'object' ? key : legacy_type_parameter;
+			const last_bracket_child = node.nameType ?? constraint ?? first_bracket_child;
 
 			// `readonly` / `+readonly` / `-readonly` modifier
 			if (node.readonly) {
@@ -2225,11 +2285,7 @@ export default (options = {}) => {
 				);
 			}
 
-			context.write('[');
-
-			const legacy_type_parameter = node.typeParameter;
-			const key = node.key ?? legacy_type_parameter?.name;
-			const constraint = node.constraint ?? legacy_type_parameter?.constraint;
+			context.write('[', enclosing_token(node, first_bracket_child, '['));
 
 			if (key && typeof key === 'object') {
 				context.visit(key);
@@ -2248,7 +2304,7 @@ export default (options = {}) => {
 				context.visit(node.nameType);
 			}
 
-			context.write(']');
+			context.write(']', enclosing_token(node, last_bracket_child, ']'));
 
 			// `?` / `+?` / `-?` optionality modifier
 			if (node.optional) {
@@ -2260,7 +2316,7 @@ export default (options = {}) => {
 				context.visit(node.typeAnnotation);
 			}
 
-			context.write('}');
+			context.write('}', token_before(node.loc?.end));
 		},
 
 		TSMethodSignature(node, context) {
@@ -2269,39 +2325,34 @@ export default (options = {}) => {
 				write_keyword(context, node, node.kind, ' ');
 			}
 
-			if (node.computed) context.write('[', token_before(node.key.loc?.start));
+			if (node.computed) context.write('[', enclosing_token(node, node.key, '['));
 			context.visit(node.key);
-			if (node.computed) context.write(']', token_at(node.key.loc?.end));
+			if (node.computed) context.write(']', enclosing_token(node, node.key, ']'));
 			if (node.optional) context.write('?');
 
 			if (node.typeParameters) {
 				context.visit(node.typeParameters);
 			}
 
-			// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
-			track_bindings(node.parameters ?? node.params);
-			context.write('(');
-			sequence(
+			const parameters = signature_parameters(node);
+			const return_type = signature_return_type(node);
+			track_bindings(parameters);
+			write_params(
 				context,
-				// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
-				node.parameters ?? node.params,
-				// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
-				(node.typeAnnotation ?? node.returnType)?.loc?.start ?? null,
-				false
+				node,
+				parameters,
+				node.typeParameters ?? node.key,
+				return_type,
+				return_type?.loc?.start ?? null
 			);
-			context.write(')');
 
-			// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
-			if (node.typeAnnotation || node.returnType) {
-				// @ts-expect-error `acorn-typescript` and `@typescript-eslint/types` have slightly different type definitions
-				context.visit(node.typeAnnotation ?? node.returnType);
-			}
+			if (return_type) context.visit(return_type);
 		},
 
 		TSTupleType(node, context) {
-			context.write('[');
+			context.write('[', token_at(node.loc?.start));
 			sequence(context, node.elementTypes, node.loc?.end ?? null, false);
-			context.write(']');
+			context.write(']', token_before(node.loc?.end));
 		},
 
 		TSNamedTupleMember(node, context) {
@@ -2350,16 +2401,18 @@ export default (options = {}) => {
 		TSConstructorType: shared['TSFunctionType|TSConstructorType'],
 
 		TSExternalModuleReference(node, context) {
-			context.write('require(');
+			context.write('require');
+			context.write('(', opening_paren(node));
 			context.visit(node.expression);
-			context.write(');');
+			context.write(')', token_before(node.loc?.end));
+			context.write(';');
 		},
 
 		TSIndexedAccessType(node, context) {
 			context.visit(node.objectType);
-			context.write('[');
+			context.write('[', enclosing_token(node, node.indexType, '['));
 			context.visit(node.indexType);
-			context.write(']');
+			context.write(']', token_before(node.loc?.end));
 		},
 
 		TSImportEqualsDeclaration(node, context) {
@@ -2371,9 +2424,10 @@ export default (options = {}) => {
 		},
 
 		TSImportType(node, context) {
-			context.write('import(');
+			context.write('import');
+			context.write('(', opening_paren(node));
 			context.visit(node.argument);
-			context.write(')');
+			context.write(')', located_token(node, ')', node.argument.loc?.end, 'after'));
 
 			if (node.qualifier) {
 				context.write('.');
@@ -2414,23 +2468,25 @@ export default (options = {}) => {
 			if (node.const) context.write('const ');
 			context.write('enum ');
 			context.visit(node.id);
-			context.write(' {');
+			context.write(' ');
+			context.write('{', located_token(node, '{', node.id.loc?.end, 'after'));
 			context.indent();
 			context.newline();
 			sequence(context, node.members ?? node.body.members, node.loc?.end ?? null, false);
 			context.dedent();
 			context.newline();
-			context.write('}');
+			context.write('}', token_before(node.loc?.end));
 		},
 
 		TSModuleBlock(node, context) {
-			context.write(' {');
+			context.write(' ');
+			context.write('{', token_at(node.loc?.start));
 			context.indent();
 			context.newline();
 			body(context, node);
 			context.dedent();
 			context.newline();
-			context.write('}');
+			context.write('}', token_before(node.loc?.end));
 		},
 
 		TSModuleDeclaration(node, context) {
@@ -2479,9 +2535,10 @@ export default (options = {}) => {
 				context.write(' extends ');
 				sequence(context, node.extends, node.body.loc?.start ?? null, false);
 			}
-			context.write(' {');
+			context.write(' ');
+			context.write('{', token_at(node.body.loc?.start));
 			context.visit(node.body);
-			context.write('}');
+			context.write('}', token_before(node.body.loc?.end));
 		},
 
 		TSInstantiationExpression(node, context) {
@@ -2501,7 +2558,7 @@ export default (options = {}) => {
 
 		//@ts-expect-error I don't know why, but this is relied upon in the tests, but doesn't exist in the TSESTree types
 		TSParenthesizedType(node, context) {
-			maybe_wrap(context, node.typeAnnotation, true);
+			write_parenthesized(context, node, node.typeAnnotation);
 		},
 
 		TSSatisfiesExpression(node, context) {
@@ -2881,7 +2938,23 @@ function quote(string, char) {
  * @param {{ line: number, column: number }} b
  */
 function before(a, b) {
-	if (a.line < b.line) return true;
-	if (a.line > b.line) return false;
-	return a.column < b.column;
+	return compare_positions(a, b) < 0;
+}
+
+/**
+ * `acorn-typescript` and `@typescript-eslint/types` name the parameter list
+ * of signatures differently
+ * @param {{ params: TSESTree.Parameter[], parameters?: TSESTree.Parameter[] }} node
+ */
+function signature_parameters(node) {
+	return node.parameters ?? node.params;
+}
+
+/**
+ * `acorn-typescript` and `@typescript-eslint/types` name the return type of
+ * signatures differently
+ * @param {{ returnType: TSESTree.TSTypeAnnotation | undefined, typeAnnotation?: TSESTree.TSTypeAnnotation }} node
+ */
+function signature_return_type(node) {
+	return node.typeAnnotation ?? node.returnType;
 }

--- a/src/languages/ts/public.d.ts
+++ b/src/languages/ts/public.d.ts
@@ -1,6 +1,6 @@
 import type { Visitors, BaseNode } from '../../types';
-import type { TSOptions, BaseComment, Comment } from '../types';
-export type { BaseComment, Comment };
+import type { TSOptions, BaseComment, Comment, SourceToken } from '../types';
+export type { BaseComment, Comment, SourceToken };
 export type Node = BaseNode;
 export default function ts(options?: TSOptions): Visitors<BaseNode>;
 // was Record<TSESTree.Expression['type'] | 'Super' | 'RestElement', number>

--- a/src/languages/tsx/index.js
+++ b/src/languages/tsx/index.js
@@ -2,143 +2,150 @@
 /** @import { Visitors } from '../../types.js' */
 /** @import { TSOptions } from '../types.js' */
 import ts from '../ts/index.js';
+import { boundary_tokens } from '../ts/boundary-tokens.js';
 
 /**
  * @param {TSOptions} [options]
  * @returns {Visitors<TSESTree.Node>}
  */
-export default (options) => ({
-	...ts(options),
+export default (options) => {
+	const { token_at, token_before } = boundary_tokens(options ?? {});
 
-	JSXElement(node, context) {
-		context.visit(node.openingElement);
+	return {
+		...ts(options),
 
-		if (node.children.length > 0) {
-			context.indent();
+		JSXElement(node, context) {
+			context.visit(node.openingElement);
+
+			if (node.children.length > 0) {
+				context.indent();
+			}
+
+			for (const child of node.children) {
+				context.visit(child);
+			}
+
+			if (node.children.length > 0) {
+				context.dedent();
+			}
+
+			if (node.closingElement) {
+				context.visit(node.closingElement);
+			}
+		},
+
+		JSXOpeningElement(node, context) {
+			context.write('<');
+
+			context.visit(node.name);
+
+			// explicit type arguments (`<Comp<string> ... />`)
+			if (node.typeArguments) {
+				context.visit(node.typeArguments);
+			}
+
+			for (const attribute of node.attributes) {
+				context.write(' ');
+				context.visit(attribute);
+			}
+
+			if (node.selfClosing) {
+				context.write(' /');
+			}
+
+			context.write('>');
+		},
+
+		JSXClosingElement(node, context) {
+			context.write('</');
+
+			context.visit(node.name);
+
+			context.write('>');
+		},
+
+		JSXNamespacedName(node, context) {
+			context.visit(node.namespace);
+			context.write(':');
+			context.visit(node.name);
+		},
+
+		JSXIdentifier(node, context) {
+			context.write(node.name, node);
+		},
+
+		JSXMemberExpression(node, context) {
+			context.visit(node.object);
+			context.write('.');
+			context.visit(node.property);
+		},
+
+		JSXText(node, context) {
+			// `value` is decoded — re-emitting it would turn `&lt;`, `&gt;`, `&#123;`
+			// and `&#125;` back into characters that can't appear in JSX text
+			context.write(node.raw ?? node.value, node);
+		},
+
+		JSXAttribute(node, context) {
+			context.visit(node.name);
+			if (node.value) {
+				context.write('=');
+				context.visit(node.value);
+			}
+		},
+
+		JSXEmptyExpression(node, context) {},
+
+		JSXFragment(node, context) {
+			context.visit(node.openingFragment);
+
+			if (node.children.length > 0) {
+				context.indent();
+			}
+
+			for (const child of node.children) {
+				context.visit(child);
+			}
+
+			if (node.children.length > 0) {
+				context.dedent();
+			}
+
+			context.visit(node.closingFragment);
+		},
+
+		JSXOpeningFragment(node, context) {
+			context.write('<>');
+		},
+
+		JSXClosingFragment(node, context) {
+			context.write('</>');
+		},
+
+		JSXExpressionContainer(node, context) {
+			context.write('{', token_at(node.loc?.start));
+
+			context.visit(node.expression);
+
+			context.write('}', token_before(node.loc?.end));
+		},
+
+		JSXSpreadChild(node, context) {
+			context.write('{', token_at(node.loc?.start));
+			context.write('...');
+
+			context.visit(node.expression);
+
+			context.write('}', token_before(node.loc?.end));
+		},
+
+		JSXSpreadAttribute(node, context) {
+			context.write('{', token_at(node.loc?.start));
+			context.write('...');
+
+			context.visit(node.argument);
+
+			context.write('}', token_before(node.loc?.end));
 		}
-
-		for (const child of node.children) {
-			context.visit(child);
-		}
-
-		if (node.children.length > 0) {
-			context.dedent();
-		}
-
-		if (node.closingElement) {
-			context.visit(node.closingElement);
-		}
-	},
-
-	JSXOpeningElement(node, context) {
-		context.write('<');
-
-		context.visit(node.name);
-
-		// explicit type arguments (`<Comp<string> ... />`)
-		if (node.typeArguments) {
-			context.visit(node.typeArguments);
-		}
-
-		for (const attribute of node.attributes) {
-			context.write(' ');
-			context.visit(attribute);
-		}
-
-		if (node.selfClosing) {
-			context.write(' /');
-		}
-
-		context.write('>');
-	},
-
-	JSXClosingElement(node, context) {
-		context.write('</');
-
-		context.visit(node.name);
-
-		context.write('>');
-	},
-
-	JSXNamespacedName(node, context) {
-		context.visit(node.namespace);
-		context.write(':');
-		context.visit(node.name);
-	},
-
-	JSXIdentifier(node, context) {
-		context.write(node.name, node);
-	},
-
-	JSXMemberExpression(node, context) {
-		context.visit(node.object);
-		context.write('.');
-		context.visit(node.property);
-	},
-
-	JSXText(node, context) {
-		// `value` is decoded — re-emitting it would turn `&lt;`, `&gt;`, `&#123;`
-		// and `&#125;` back into characters that can't appear in JSX text
-		context.write(node.raw ?? node.value, node);
-	},
-
-	JSXAttribute(node, context) {
-		context.visit(node.name);
-		if (node.value) {
-			context.write('=');
-			context.visit(node.value);
-		}
-	},
-
-	JSXEmptyExpression(node, context) {},
-
-	JSXFragment(node, context) {
-		context.visit(node.openingFragment);
-
-		if (node.children.length > 0) {
-			context.indent();
-		}
-
-		for (const child of node.children) {
-			context.visit(child);
-		}
-
-		if (node.children.length > 0) {
-			context.dedent();
-		}
-
-		context.visit(node.closingFragment);
-	},
-
-	JSXOpeningFragment(node, context) {
-		context.write('<>');
-	},
-
-	JSXClosingFragment(node, context) {
-		context.write('</>');
-	},
-
-	JSXExpressionContainer(node, context) {
-		context.write('{');
-
-		context.visit(node.expression);
-
-		context.write('}');
-	},
-
-	JSXSpreadChild(node, context) {
-		context.write('{...');
-
-		context.visit(node.expression);
-
-		context.write('}');
-	},
-
-	JSXSpreadAttribute(node, context) {
-		context.write('{...');
-
-		context.visit(node.argument);
-
-		context.write('}');
-	}
-});
+	};
+};

--- a/src/languages/tsx/public.d.ts
+++ b/src/languages/tsx/public.d.ts
@@ -1,5 +1,5 @@
 import type { Visitors, BaseNode } from '../../types';
-import type { TSOptions, BaseComment, Comment } from '../types';
-export type { BaseComment, Comment };
+import type { TSOptions, BaseComment, Comment, SourceToken } from '../types';
+export type { BaseComment, Comment, SourceToken };
 export type Node = BaseNode;
 export default function tsx(options?: TSOptions): Visitors<BaseNode>;

--- a/src/languages/types.d.ts
+++ b/src/languages/types.d.ts
@@ -3,13 +3,21 @@ import type { BaseNode } from '../types';
 export type TSOptions = {
 	quotes?: 'double' | 'single';
 	/**
-	 * Anchor structural tokens (array/object brackets and braces, preserved
-	 * parentheses, unary operators, and the closing tokens of calls and
-	 * computed member access) with one-character source locations, so
-	 * node-boundary positions always resolve through the source map instead of
-	 * being attributed to the previous token. Denser maps; identical output.
+	 * Anchor structural tokens (brackets, braces, parentheses, unary operators)
+	 * with their source locations, so those positions resolve through the source
+	 * map instead of being attributed to the previous token. Tokens at a node's
+	 * own boundary are located from its `loc`; tokens internal to a node (the
+	 * brackets of a computed key, the parentheses of a call or an `if`) are
+	 * located from `tokens` when supplied, and are otherwise left unmapped.
+	 * Denser maps; identical output.
 	 */
 	boundaryTokens?: boolean;
+	/**
+	 * The parser's tokens, with locations — for example Acorn's `onToken` array,
+	 * Babel's `tokens`, or an ESLint-style `ast.tokens`. Used with
+	 * `boundaryTokens` to locate delimiters that node boundaries cannot give.
+	 */
+	tokens?: readonly SourceToken[];
 	comments?: Comment[];
 	getLeadingComments?: (node: BaseNode) => BaseComment[] | undefined;
 	getTrailingComments?: (node: BaseNode) => BaseComment[] | undefined;
@@ -18,6 +26,20 @@ export type TSOptions = {
 interface Position {
 	line: number;
 	column: number;
+}
+
+/**
+ * A parser token. The punctuator it stands for is read from `type.label`
+ * (Acorn, Babel) or, for `type: 'Punctuator'` tokens (espree,
+ * typescript-eslint), from `value`.
+ */
+export interface SourceToken {
+	type?: string | { label?: string };
+	value?: unknown;
+	loc?: null | {
+		start: Position;
+		end: Position;
+	};
 }
 
 // this exists in TSESTree but because of the inanity around enums

--- a/test/common.js
+++ b/test/common.js
@@ -10,7 +10,7 @@ export const acornTs = acorn.Parser.extend(tsPlugin());
 export const acornTsx = acorn.Parser.extend(tsPlugin({ jsx: true }));
 
 /** @param {string} input
- * @param {{ jsxMode?: boolean, sourceType?: 'module' | 'script', preserveParens?: boolean, fileExtension?: string }} opts
+ * @param {{ jsxMode?: boolean, sourceType?: 'module' | 'script', preserveParens?: boolean, fileExtension?: string, tokens?: any[] }} opts
  */
 export function acornParse(input, opts = {}) {
 	const jsx = opts.jsxMode ?? false;
@@ -24,6 +24,7 @@ export function acornParse(input, opts = {}) {
 		sourceType,
 		locations: true,
 		preserveParens: opts.preserveParens ?? false,
+		onToken: opts.tokens,
 		onComment: (block, value, start, end, startLoc, endLoc) => {
 			if (block && /\n/.test(value)) {
 				let a = start;

--- a/test/sourcemap-keywords.test.js
+++ b/test/sourcemap-keywords.test.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { expect, test } from 'vitest';
 import ts from '../src/languages/ts/index.js';
+import tsx from '../src/languages/tsx/index.js';
 import { print } from '../src/index.js';
 import { acornParse } from './common.js';
 
@@ -23,39 +24,128 @@ function generatedLineColumn(code, index) {
  * @returns {[number, number, number, number]}
  */
 function mappingAtSubstring(code, needle, mappings) {
-	const idx = code.indexOf(needle);
-	expect(idx >= 0, `needle not in output: ${JSON.stringify(needle)}`).toBe(true);
-	const { gen_line, gen_col } = generatedLineColumn(code, idx);
-	const line = mappings[gen_line];
-	expect(line).toBeDefined();
-	const line_segments = /** @type {[number, number, number, number][]} */ (line);
-
-	const segment = line_segments.find((s) => s[0] === gen_col);
+	const segments = mappingsAtSubstring(code, needle, mappings);
+	const segment = segments[0];
 	expect(segment).toBeDefined();
 	return /** @type {[number, number, number, number]} */ (segment);
 }
 
 /**
+ * @param {string} code
+ * @param {string} needle
+ * @param {[number, number, number, number][][]} mappings
+ * @returns {[number, number, number, number][]}
+ */
+function mappingsAtSubstring(code, needle, mappings) {
+	const idx = code.indexOf(needle);
+	expect(idx >= 0, `needle not in output: ${JSON.stringify(needle)}`).toBe(true);
+	return mappingsAtIndex(code, idx, mappings);
+}
+
+/**
+ * @param {string} code
+ * @param {number} index
+ * @param {[number, number, number, number][][]} mappings
+ * @returns {[number, number, number, number][]}
+ */
+function mappingsAtIndex(code, index, mappings) {
+	const { gen_line, gen_col } = generatedLineColumn(code, index);
+	const line = mappings[gen_line];
+	expect(line).toBeDefined();
+	const line_segments = /** @type {[number, number, number, number][]} */ (line);
+	return line_segments.filter((segment) => segment[0] === gen_col);
+}
+
+/**
  * @param {string} source
- * @param {{ preserveParens?: boolean, boundaryTokens?: boolean }} [opts]
+ * @param {{ preserveParens?: boolean, boundaryTokens?: boolean, tokens?: boolean | any[], jsx?: boolean, sourceType?: 'module' | 'script' }} [opts]
  */
 function mapped(source, opts = {}) {
+	/** @type {any[]} the parser's tokens; passed to the printer when `opts.tokens` is `true` */
+	const tokens = [];
 	const { ast, comments } = acornParse(source, {
 		preserveParens: opts.preserveParens,
-		sourceType: 'module',
-		jsxMode: false,
-		fileExtension: 'ts'
+		sourceType: opts.sourceType ?? 'module',
+		jsxMode: opts.jsx ?? false,
+		fileExtension: opts.jsx ? 'tsx' : 'ts',
+		tokens
 	});
-	const { code, map } = print(ast, ts({ comments, boundaryTokens: opts.boundaryTokens }), {
-		sourceMapSource: 'input.ts',
-		sourceMapContent: source,
-		sourceMapEncodeMappings: false
-	});
+	const language = opts.jsx ? tsx : ts;
+	const { code, map } = print(
+		ast,
+		language({
+			comments,
+			boundaryTokens: opts.boundaryTokens,
+			tokens: opts.tokens === true ? tokens : opts.tokens || undefined
+		}),
+		{
+			sourceMapSource: 'input.ts',
+			sourceMapContent: source,
+			sourceMapEncodeMappings: false
+		}
+	);
 	expect(map.mappings).toBeTruthy();
 	const mappings = /** @type {[number, number, number, number][][]} */ (
 		/** @type {unknown} */ (map.mappings)
 	);
-	return { source, code, mappings };
+	return { source, code, mappings, tokens };
+}
+
+/**
+ * @param {string} source
+ * @param {string[]} delimiters
+ * @param {{ tokens?: boolean, jsx?: boolean, sourceType?: 'module' | 'script' }} [opts]
+ */
+function expectExactDelimiterMappings(source, delimiters, opts = {}) {
+	const inferred = mapped(source, {
+		boundaryTokens: true,
+		jsx: opts.jsx,
+		sourceType: opts.sourceType
+	});
+	const { code, mappings, tokens } = mapped(source, {
+		boundaryTokens: true,
+		tokens: opts.tokens,
+		jsx: opts.jsx,
+		sourceType: opts.sourceType
+	});
+	expect(code).toBe(inferred.code);
+
+	// a backtracking parser can emit a token twice
+	const seen = new Set();
+	/** @type {{ value: string, start: { line: number, column: number } }[]} */
+	const source_delimiters = [];
+	for (const token of tokens) {
+		const value = token.type.label;
+		if (!token.loc || !delimiters.includes(value === '${' ? '{' : value)) continue;
+		const key = `${value}:${token.loc.start.line}:${token.loc.start.column}`;
+		if (seen.has(key)) continue;
+		seen.add(key);
+		source_delimiters.push({ value, start: token.loc.start });
+	}
+
+	/** @type {{ value: string, index: number }[]} */
+	const generated_delimiters = [];
+	for (let i = 0; i < code.length; i += 1) {
+		if (code[i] === '$' && code[i + 1] === '{' && delimiters.includes('{')) {
+			generated_delimiters.push({ value: '${', index: i });
+			i += 1;
+		} else if (delimiters.includes(code[i])) {
+			generated_delimiters.push({ value: code[i], index: i });
+		}
+	}
+
+	expect(generated_delimiters.map((d) => d.value)).toEqual(source_delimiters.map((d) => d.value));
+	for (let i = 0; i < generated_delimiters.length; i += 1) {
+		const { start } = source_delimiters[i];
+		expect(
+			mappingsAtIndex(code, generated_delimiters[i].index, mappings).map((s) => s.slice(2))
+		).toContainEqual([start.line - 1, start.column]);
+	}
+}
+
+/** @param {string} source */
+function expectExactBracketMappings(source) {
+	expectExactDelimiterMappings(source, ['[', ']'], { tokens: true });
 }
 
 test('source mappings land on keywords (let / function / async / export)', () => {
@@ -263,4 +353,171 @@ test('source mappings anchor preserved parentheses', () => {
 
 	const seg_close = mappingAtSubstring(code, ')', mappings);
 	expect(seg_close[3]).toBe(source.indexOf(')'));
+});
+
+test.each([
+	['object property', `const object = { [\nkey\n]: value };`],
+	['object method', `const object = { async *[\nmethod\n]() {} };`],
+	['object getter', `const object = { get [\nkey\n]() { return 1; } };`],
+	['object setter', `const object = { set [\nkey\n](value) {} };`],
+	['class method', `class Example { [\nmethod\n]() {} }`],
+	['class field', `class Example { [\nfield\n] = 1; }`],
+	['type property signature', `type Example = { [\nkey\n]: string }`],
+	['type method signature', `type Example = { [\nmethod\n](): void }`]
+])('source mappings use supplied computed-key boundary locations for %s', (_name, source) => {
+	expectExactBracketMappings(source);
+});
+
+test('supplied computed-key locations can span comments and line breaks', () => {
+	expectExactBracketMappings(`const object = { [ /* before */\nkey\n/* after */ ]: value };`);
+});
+
+test('computed-key brackets are not guessed without tokens', () => {
+	// the old inference would anchor `[` to the space before `key`
+	const { code, mappings } = mapped(`const object = { [ key ]: value };`, { boundaryTokens: true });
+	expect(mappingsAtSubstring(code, '[', mappings)).toEqual([]);
+});
+
+test('tokens without locations leave mappings unchanged', () => {
+	const source = `const object = { [key]: fn(value) };`;
+	const { mappings, tokens } = mapped(source, { boundaryTokens: true });
+	const bare = tokens.map(({ type, value }) => ({ type, value }));
+	expect(mapped(source, { boundaryTokens: true, tokens: bare }).mappings).toEqual(mappings);
+	expect(mapped(source, { boundaryTokens: true, tokens: [] }).mappings).toEqual(mappings);
+});
+
+test('tokens out of source order still locate delimiters', () => {
+	// acorn-typescript backtracks and re-emits tokens, so its stream is not monotone
+	const source = `const object = { [ key ]: fn( value ) };`;
+	const { mappings, tokens } = mapped(source, { boundaryTokens: true, tokens: true });
+	const reversed = [...tokens].reverse();
+	expect(mapped(source, { boundaryTokens: true, tokens: reversed }).mappings).toEqual(mappings);
+});
+
+test('ESLint-style punctuator tokens locate delimiters', () => {
+	const source = `const object = { [ key ]: fn( value ) };`;
+	const { mappings, tokens } = mapped(source, { boundaryTokens: true, tokens: true });
+	const punctuators = tokens.map((token) => ({
+		type: 'Punctuator',
+		value: token.type.label,
+		loc: token.loc
+	}));
+	expect(mapped(source, { boundaryTokens: true, tokens: punctuators }).mappings).toEqual(mappings);
+});
+
+test.each([
+	['array expression', `const values = [ /* before */\nvalue\n/* after */ ];`],
+	['array pattern', `const [ /* before */\nvalue\n/* after */ ] = values;`],
+	['computed member access', `const value = object[ /* before */\nkey\n/* after */ ];`],
+	['array type', `type Values = Item /* before */ [ /* after */ ];`],
+	['index signature', `type Dictionary = { [ /* before */ key: string /* after */ ]: number };`],
+	[
+		'mapped type',
+		`type Selected = { [ /* before */ K in Keys as Rename<K> /* after */ ]: string };`
+	],
+	['tuple type', `type Pair = [ /* before */ First, Second /* after */ ];`],
+	['indexed access type', `type Value = Object[ /* before */ Key /* after */ ];`]
+])('source mappings use supplied square-bracket locations for %s', (_name, source) => {
+	expectExactBracketMappings(source);
+});
+
+test.each([
+	['block', `function example() { return; }`, ['{', '}'], {}],
+	['type literal', `type Example = { value: string };`, ['{', '}'], {}],
+	['mapped type', `type Example = { [K in Keys]: string };`, ['{', '}'], {}],
+	['module block', `namespace Example { export const value = 1; }`, ['{', '}'], {}],
+	['interface body', `interface Example { value: string }`, ['{', '}'], {}],
+	['parenthesized type', `type Example = (First | Second);`, ['(', ')'], {}],
+	['JSX expression container', `const element = <div>{value}</div>;`, ['{', '}'], { jsx: true }],
+	['JSX spread attribute', `const element = <div {...props} />;`, ['{', '}'], { jsx: true }]
+])('boundaryTokens maps outer delimiters for %s', (_name, source, delimiters, opts) => {
+	expectExactDelimiterMappings(source, delimiters, opts);
+});
+
+test.each([
+	['call expression', `const result = fn /* before */ ( /* inside */ value /* after */ );`, {}],
+	[
+		'new expression',
+		`const result = new Thing /* before */ ( /* inside */ value /* after */ );`,
+		{}
+	],
+	[
+		'function declaration',
+		`function example /* before */ ( /* inside */ value /* after */ ) {}`,
+		{}
+	],
+	['class method', `class Example { method /* before */ ( value /* after */ ) {} }`, {}],
+	['object method', `const object = { method /* before */ ( value /* after */ ) {} };`, {}],
+	['arrow function', `const callback = ( /* before */ value /* after */ ) => value;`, {}],
+	['empty arrow function', `const callback = /* before */ () => value;`, {}],
+	['nested method delimiters', `class Example { [getKey()] /* before */ (value = make()) {} }`, {}],
+	['nested parameter delimiters', `function example(value = make(1)) {}`, {}],
+	['call signature', `type Example = { ( /* before */ value: string /* after */ ): void };`, {}],
+	[
+		'construct signature',
+		`type Example = { new ( /* before */ value: string /* after */ ): object };`,
+		{}
+	],
+	['function type', `type Example = ( /* before */ value: string /* after */ ) => void;`, {}],
+	[
+		'constructor type',
+		`type Example = new ( /* before */ value: string /* after */ ) => object;`,
+		{}
+	],
+	[
+		'method signature',
+		`type Example = { method( /* before */ value: string /* after */ ): void };`,
+		{}
+	],
+	[
+		'declare function',
+		`declare function example( /* before */ value: string /* after */ ): void;`,
+		{}
+	],
+	['for statement', `for /* before */ (let i = 0; i < 1; i += 1) {}`, {}],
+	['for-of statement', `for /* before */ (const value of values) {}`, {}],
+	['if statement', `if /* before */ (condition /* after */) {}`, {}],
+	['while statement', `while /* before */ (condition /* after */) {}`, {}],
+	['do-while statement', `do {} while /* before */ (condition /* after */);`, {}],
+	['with statement', `with /* before */ (object /* after */) {}`, { sourceType: 'script' }],
+	['switch statement', `switch /* before */ (value /* after */) { default: break; }`, {}],
+	['catch clause', `try {} catch /* before */ (error /* after */) {}`, {}],
+	['import expression', `const module = import( /* before */ 'module' /* after */ );`, {}],
+	['external module reference', `import Alias = require( /* before */ 'module' /* after */ );`, {}],
+	['import type', `type Value = import( /* before */ 'module' /* after */ ).Value;`, {}]
+])('supplied tokens map internal parentheses for %s', (_name, source, opts) => {
+	expectExactDelimiterMappings(source, ['(', ')'], {
+		tokens: true,
+		sourceType: 'sourceType' in opts && opts.sourceType === 'script' ? 'script' : undefined
+	});
+});
+
+test.each([
+	['named import', `import { /* before */ value /* after */ } from 'module';`],
+	['empty named export', `export { /* inside */ };`],
+	['import attributes', `import value from 'module' with { type: 'json' };`],
+	['static block', `class Example { static /* before */ { value; } }`],
+	['switch body', `switch (value) /* before */ { default: break; }`],
+	['enum body', `enum Example /* before */ { Value }`],
+	['template interpolation', 'const result = `before ${ /* before */ value /* after */ } after`;'],
+	['template-literal type interpolation', 'type Result = `before ${Value} after`;']
+])('supplied tokens map internal curly braces for %s', (_name, source) => {
+	expectExactDelimiterMappings(source, ['{', '}'], { tokens: true });
+});
+
+test('control-flow mappings select the outer authored parentheses', () => {
+	const source = `if /* before */ ((condition)) {}`;
+	const { code, mappings, tokens } = mapped(source, { boundaryTokens: true, tokens: true });
+	const opens = tokens.filter((token) => token.type.label === '(');
+	const closes = tokens.filter((token) => token.type.label === ')');
+
+	expect(
+		mappingsAtSubstring(code, '(', mappings).map((segment) => segment.slice(2))
+	).toContainEqual([opens[0].loc.start.line - 1, opens[0].loc.start.column]);
+	expect(
+		mappingsAtSubstring(code, ')', mappings).map((segment) => segment.slice(2))
+	).toContainEqual([
+		closes[closes.length - 1].loc.start.line - 1,
+		closes[closes.length - 1].loc.start.column
+	]);
 });


### PR DESCRIPTION
## Problem

For a computed key like `{ [\nkey\n]: value }` the AST only records the key expression's location; the brackets' positions cannot be derived from node boundaries. `boundaryTokens` (#148) anchored them by assuming they sit one character before and after the key, which is wrong whenever whitespace, newlines or comments separate bracket and key. That was the one case in the feature that guessed; every other boundary token is derived from a node's own span.

## Change (`minor`)

- **New `tokens` option** on `ts()` / `tsx()`: the parser's token stream, in any of the common shapes (Acorn `onToken` with `type.label`, Babel `tokens`, ESLint-style `{ type: 'Punctuator', value }`). Only consulted when `boundaryTokens` is on.
- With tokens, the brackets of computed keys, the parentheses of calls, functions, signatures and control-flow statements, and the braces of import/export lists, enums, static blocks and template interpolations are anchored to their real positions. The lookup is a binary search over the delimiter tokens for the nearest match on the right side of a known AST position, never leaving the owning node.
- Without tokens those delimiters are left unmapped rather than guessed. Node-boundary anchors and printed output are unchanged.
- The delimiter index sorts on demand: acorn-typescript re-emits tokens when it backtracks, so its `onToken` array is not monotone and a plain binary search would silently miss brackets.
- The machinery lives in `src/languages/ts/boundary-tokens.js`, memoised per options object and shared with `tsx`. `write_params`, `write_keyword_paren` and `write_parenthesized` replace the per-visitor copies of the same open/close pattern.

```js
const tokens = [];
const ast = acorn.parse(source, { locations: true, onToken: tokens, ... });
print(ast, ts({ comments, boundaryTokens: true, tokens }));
```

## Tests

`test/sourcemap-keywords.test.js` checks, per construct, that every source delimiter maps to its exact position and that output is byte-identical with and without tokens, plus: comments and line breaks inside brackets, the no-guess behaviour without tokens, tokens without locations, empty tokens, ESLint-style tokens, and out-of-order tokens.

## Related

The bug fixes that were previously bundled here are now separate PRs: #184 (object-literal method type parameters), #185 (comments after a signature's `)` or `=>`), #186 (semicolon after body-less class methods). This PR preserves current behaviour in all three areas; the explicit `until` arguments passed to `write_params` by the three signature visitors exist only to keep the comment bound unchanged and can go once #185 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
