### PR TITLE
fix: print the type parameters of object-literal methods

### DIFF
--- a/.changeset/object-method-type-parameters.md
+++ b/.changeset/object-method-type-parameters.md
@@ -1,0 +1,5 @@
+---
+'esrap': patch
+---
+
+Print the type parameters of object-literal methods

--- a/.changeset/object-method-type-parameters.md
+++ b/.changeset/object-method-type-parameters.md
@@ -2,4 +2,4 @@
 'esrap': patch
 ---
 
-Print the type parameters of object-literal methods
+fix: print type parameters of object-literal methods

--- a/src/languages/ts/index.js
+++ b/src/languages/ts/index.js
@@ -1656,6 +1656,7 @@ export default (options = {}) => {
 				if (node.computed) context.write('[', token_before(node.key.loc?.start));
 				context.visit(node.key);
 				if (node.computed) context.write(']', token_at(node.key.loc?.end));
+				if (node.value.typeParameters) context.visit(node.value.typeParameters);
 				track_bindings(node.value.params);
 				context.write('(');
 				sequence(

--- a/test/object-method-type-parameters.test.js
+++ b/test/object-method-type-parameters.test.js
@@ -1,0 +1,24 @@
+// @ts-check
+import { expect, test } from 'vitest';
+import { oxcParse } from './common.js';
+import { print } from '../src/index.js';
+import ts from '../src/languages/ts/index.js';
+
+// acorn-typescript cannot parse type parameters on object-literal methods, so oxc parses this
+test('object-literal methods keep their type parameters', () => {
+	const input = `const object = {
+	async *[method]<T>(value: T): AsyncGenerator<T> {},
+	get [getter](): T { return value; },
+	set [setter](value: T) {}
+};`;
+
+	const { ast, comments } = oxcParse(input, { fileExtension: 'ts' });
+
+	expect(print(ast, ts({ comments })).code).toBe(`const object = {
+	async *[method]<T>(value: T): AsyncGenerator<T> {},
+	get [getter](): T {
+		return value;
+	},
+	set [setter](value: T) {}
+};`);
+});

--- a/test/samples/ts-comment-signature/expected.ts.map
+++ b/test/samples/ts-comment-signature/expected.ts.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": [
+    "input.js"
+  ],
+  "sourcesContent": [
+    null
+  ],
+  "mappings": ""
+}


### PR DESCRIPTION
Split out of #183 at the maintainers' request.

Object-literal methods lost their type parameters when printed: `{ m<T>(x: T) {} }` came out as `{ m(x: T) {} }`. The `Property` visitor's method branch never visited `value.typeParameters`.

The test parses with oxc because acorn-typescript cannot parse type parameters on object-literal methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
